### PR TITLE
Add Android and iOS build support and restore all targets

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,127 @@
+name: Build PDFium & Deploy to falcon-pdfium-binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (default: android-ios-build)'
+        required: false
+        default: android-ios-build
+
+permissions:
+  contents: read
+
+jobs:
+  build-android:
+    name: Build Android (${{ matrix.target }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: arm64-v8a, output_dir: android-arm64 }
+          - { target: armeabi-v7a, output_dir: android-arm }
+          - { target: x86, output_dir: android-x86 }
+          - { target: x86_64, output_dir: android-x64 }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install depot_tools
+        run: |
+          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$RUNNER_TEMP/depot_tools"
+          echo "$RUNNER_TEMP/depot_tools" >> "$GITHUB_PATH"
+
+      - name: Install Linux base deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang lld curl g++ pkg-config tar
+
+      - name: Build target
+        run: scripts/embedpdf-runtime/build-target.sh "${{ matrix.target }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdfium-android-${{ matrix.target }}
+          path: out/embedpdf-runtime/${{ matrix.output_dir }}/libpdfium.so
+
+  build-ios:
+    name: Build iOS (${{ matrix.target }})
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: ios-arm64, output_dir: ios-arm64 }
+          - { target: ios-simulator-arm64, output_dir: ios-simulator-arm64 }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install depot_tools
+        run: |
+          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$RUNNER_TEMP/depot_tools"
+          echo "$RUNNER_TEMP/depot_tools" >> "$GITHUB_PATH"
+
+      - name: Build target
+        run: scripts/embedpdf-runtime/build-target.sh "${{ matrix.target }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdfium-${{ matrix.target }}
+          path: out/embedpdf-runtime/${{ matrix.output_dir }}/libpdfium.a
+
+  deploy:
+    name: Deploy binaries to falcon-pdfium-binaries
+    needs: [build-android, build-ios]
+    runs-on: macos-15
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Checkout falcon-pdfium-binaries
+        uses: actions/checkout@v4
+        with:
+          repository: avrapps/falcon-pdfium-binaries
+          token: ${{ secrets.PDFIUM_BINARIES_PAT }}
+          path: falcon-pdfium-binaries
+
+      - name: Copy Android binaries
+        run: |
+          cp artifacts/pdfium-android-arm64-v8a/libpdfium.so falcon-pdfium-binaries/binaries/android/arm64-v8a/libpdfium.so
+          cp artifacts/pdfium-android-armeabi-v7a/libpdfium.so falcon-pdfium-binaries/binaries/android/armeabi-v7a/libpdfium.so
+          cp artifacts/pdfium-android-x86/libpdfium.so falcon-pdfium-binaries/binaries/android/x86/libpdfium.so
+          cp artifacts/pdfium-android-x86_64/libpdfium.so falcon-pdfium-binaries/binaries/android/x86_64/libpdfium.so
+
+      - name: Build iOS xcframework
+        run: |
+          mkdir -p staging/ios-arm64 staging/ios-simulator-arm64
+          cp artifacts/pdfium-ios-arm64/libpdfium.a staging/ios-arm64/libpdfium.a
+          cp artifacts/pdfium-ios-simulator-arm64/libpdfium.a staging/ios-simulator-arm64/libpdfium.a
+
+          # Remove existing xcframework and rebuild
+          rm -rf falcon-pdfium-binaries/binaries/ios-framework/pdfium.xcframework
+          xcodebuild -create-xcframework \
+            -library staging/ios-arm64/libpdfium.a \
+            -library staging/ios-simulator-arm64/libpdfium.a \
+            -output falcon-pdfium-binaries/binaries/ios-framework/pdfium.xcframework
+
+      - name: Commit and push
+        working-directory: falcon-pdfium-binaries
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            SHORT_SHA=$(cd .. && cd artifacts && echo "${{ github.sha }}" | cut -c1-7)
+            git commit -m "chore: update pdfium binaries from avrapps/pdfium@${SHORT_SHA}"
+            git push
+          fi

--- a/.github/workflows/release-libpdfium.yml
+++ b/.github/workflows/release-libpdfium.yml
@@ -17,66 +17,22 @@ permissions:
   contents: read
 
 jobs:
-  source-tests:
-    name: Source tests (Linux x64)
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref || github.ref_name }}
-
-      - name: Install depot_tools
-        shell: bash
-        run: |
-          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$RUNNER_TEMP/depot_tools"
-          echo "$RUNNER_TEMP/depot_tools" >> "$GITHUB_PATH"
-
-      - name: Install Linux base deps
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake clang lld curl g++ pkg-config tar
-
-      - name: Run PDFium unit and embedder tests
-        shell: bash
-        run: scripts/embedpdf-runtime/test-target.sh linux-x64
-
-      - name: Upload PDFium test results
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: pdfium-source-test-results-linux-x64
-          path: out/embedpdf-runtime-test-results/linux-x64/
-          if-no-files-found: ignore
-
   build:
     name: Build ${{ matrix.target }}
-    needs: source-tests
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { target: linux-x64,        runner: ubuntu-24.04 }
-          - { target: linux-arm64,      runner: ubuntu-24.04 }
-          - { target: linuxmusl-x64,    runner: ubuntu-24.04 }
-          - { target: linuxmusl-arm64,  runner: ubuntu-24.04 }
-          - { target: wasm32,           runner: ubuntu-24.04 }
-          - { target: darwin-arm64,     runner: macos-15 }
-          - { target: darwin-x64,       runner: macos-15 }
-          - { target: win32-x64,        runner: windows-2022 }
-          - { target: win32-arm64,      runner: windows-2022 }
+          # Android
           - { target: arm64-v8a,        runner: ubuntu-24.04 }
           - { target: armeabi-v7a,      runner: ubuntu-24.04 }
           - { target: x86,              runner: ubuntu-24.04 }
           - { target: x86_64,           runner: ubuntu-24.04 }
+          # iOS
           - { target: ios-arm64,        runner: macos-15 }
           - { target: ios-simulator-arm64, runner: macos-15 }
           - { target: ios-simulator-x64,   runner: macos-15 }
-    env:
-      DEPOT_TOOLS_WIN_TOOLCHAIN: 0
-      EMSDK_VERSION: 3.1.72
-      MUSL_URLS: ${{ secrets.MUSL_URL || 'https://more.musl.cc https://musl.cc' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,71 +48,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake curl g++ pkg-config tar
-      - name: Install aarch64 cross-compiler
-        if: matrix.target == 'linux-arm64'
-        shell: bash
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-      - name: Install musl toolchain
-        if: startsWith(matrix.target, 'linuxmusl-')
-        shell: bash
-        run: |
-          triple=x86_64-linux-musl
-          if [[ "${{ matrix.target }}" == "linuxmusl-arm64" ]]; then
-            triple=aarch64-linux-musl
-          fi
-          archive="$triple-cross.tgz"
-
-          for base_url in $MUSL_URLS; do
-            url="$base_url/$archive"
-            if [[ "$base_url" == *"more.musl.cc"* ]]; then
-              url="$base_url/$triple/$archive"
-            fi
-
-            echo "Downloading $url"
-            if curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 --max-time 300 -o "$archive" "$url"; then
-              tar xzf "$archive"
-              echo "$PWD/$triple-cross/bin" >> "$GITHUB_PATH"
-              exit 0
-            fi
-          done
-
-          echo "Failed to download musl toolchain for $triple" >&2
-          exit 1
-      - name: Install Emscripten
-        if: matrix.target == 'wasm32'
-        shell: bash
-        run: |
-          mkdir -p third_party
-          if [[ -d third_party/emsdk ]]; then
-            git -C third_party/emsdk pull
-          else
-            git clone https://github.com/emscripten-core/emsdk.git third_party/emsdk
-          fi
-          third_party/emsdk/emsdk install "$EMSDK_VERSION"
-          third_party/emsdk/emsdk activate "$EMSDK_VERSION"
-          echo "$PWD/third_party/emsdk/upstream/emscripten" >> "$GITHUB_PATH"
-          echo "$PWD/third_party/emsdk/upstream/bin" >> "$GITHUB_PATH"
       - name: Select Xcode
         if: runner.os == 'macOS'
         shell: bash
         run: sudo xcode-select -s "/Applications/Xcode_16.1.app"
-      - name: Install Windows deps
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
-          $sdk = Get-ChildItem $kitsRoot -Directory |
-            Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
-            Sort-Object Name -Descending |
-            Select-Object -First 1
-          if ($null -eq $sdk) {
-            throw "No Windows SDK version directory found in $kitsRoot"
-          }
-          $rcPath = Join-Path $sdk.FullName 'x64'
-          if (!(Test-Path (Join-Path $rcPath 'rc.exe'))) {
-            throw "rc.exe not found in $rcPath"
-          }
-          $rcPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build target
         shell: bash
         run: scripts/embedpdf-runtime/build-target.sh "${{ matrix.target }}"

--- a/.github/workflows/release-libpdfium.yml
+++ b/.github/workflows/release-libpdfium.yml
@@ -14,16 +14,62 @@ on:
         default: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  source-tests:
+    name: Source tests (Linux x64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref_name }}
+
+      - name: Install depot_tools
+        shell: bash
+        run: |
+          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$RUNNER_TEMP/depot_tools"
+          echo "$RUNNER_TEMP/depot_tools" >> "$GITHUB_PATH"
+
+      - name: Install Linux base deps
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang lld curl g++ pkg-config tar
+
+      - name: Run PDFium unit and embedder tests
+        shell: bash
+        run: scripts/embedpdf-runtime/test-target.sh linux-x64
+
+      - name: Upload PDFium test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pdfium-source-test-results-linux-x64
+          path: out/embedpdf-runtime-test-results/linux-x64/
+          if-no-files-found: ignore
+
   build:
     name: Build ${{ matrix.target }}
+    needs: source-tests
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
+          # Linux & Wasm
+          - { target: linux-x64,        runner: ubuntu-24.04 }
+          - { target: linux-arm64,      runner: ubuntu-24.04 }
+          - { target: linuxmusl-x64,    runner: ubuntu-24.04 }
+          - { target: linuxmusl-arm64,  runner: ubuntu-24.04 }
+          - { target: wasm32,           runner: ubuntu-24.04 }
+          # Darwin (macOS)
+          - { target: darwin-arm64,     runner: macos-15 }
+          - { target: darwin-x64,       runner: macos-15 }
+          # Windows
+          - { target: win32-x64,        runner: windows-2022 }
+          - { target: win32-arm64,      runner: windows-2022 }
+          # Android
           - { target: arm64-v8a,        runner: ubuntu-24.04 }
           - { target: armeabi-v7a,      runner: ubuntu-24.04 }
           - { target: x86,              runner: ubuntu-24.04 }
@@ -32,6 +78,10 @@ jobs:
           - { target: ios-arm64,        runner: macos-15 }
           - { target: ios-simulator-arm64, runner: macos-15 }
           - { target: ios-simulator-x64,   runner: macos-15 }
+    env:
+      DEPOT_TOOLS_WIN_TOOLCHAIN: 0
+      EMSDK_VERSION: 3.1.72
+      MUSL_URLS: ${{ secrets.MUSL_URL || 'https://more.musl.cc https://musl.cc' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -47,10 +97,71 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake curl g++ pkg-config tar
+      - name: Install aarch64 cross-compiler
+        if: matrix.target == 'linux-arm64'
+        shell: bash
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      - name: Install musl toolchain
+        if: startsWith(matrix.target, 'linuxmusl-')
+        shell: bash
+        run: |
+          triple=x86_64-linux-musl
+          if [[ "${{ matrix.target }}" == "linuxmusl-arm64" ]]; then
+            triple=aarch64-linux-musl
+          fi
+          archive="$triple-cross.tgz"
+
+          for base_url in $MUSL_URLS; do
+            url="$base_url/$archive"
+            if [[ "$base_url" == *"more.musl.cc"* ]]; then
+              url="$base_url/$triple/$archive"
+            fi
+
+            echo "Downloading $url"
+            if curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 --max-time 300 -o "$archive" "$url"; then
+              tar xzf "$archive"
+              echo "$PWD/$triple-cross/bin" >> "$GITHUB_PATH"
+              exit 0
+            fi
+          done
+
+          echo "Failed to download musl toolchain for $triple" >&2
+          exit 1
+      - name: Install Emscripten
+        if: matrix.target == 'wasm32'
+        shell: bash
+        run: |
+          mkdir -p third_party
+          if [[ -d third_party/emsdk ]]; then
+            git -C third_party/emsdk pull
+          else
+            git clone https://github.com/emscripten-core/emsdk.git third_party/emsdk
+          fi
+          third_party/emsdk/emsdk install "$EMSDK_VERSION"
+          third_party/emsdk/emsdk activate "$EMSDK_VERSION"
+          echo "$PWD/third_party/emsdk/upstream/emscripten" >> "$GITHUB_PATH"
+          echo "$PWD/third_party/emsdk/upstream/bin" >> "$GITHUB_PATH"
       - name: Select Xcode
         if: runner.os == 'macOS'
         shell: bash
         run: sudo xcode-select -s "/Applications/Xcode_16.1.app"
+      - name: Install Windows deps
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          $sdk = Get-ChildItem $kitsRoot -Directory |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+            Sort-Object Name -Descending |
+            Select-Object -First 1
+          if ($null -eq $sdk) {
+            throw "No Windows SDK version directory found in $kitsRoot"
+          }
+          $rcPath = Join-Path $sdk.FullName 'x64'
+          if (!(Test-Path (Join-Path $rcPath 'rc.exe'))) {
+            throw "rc.exe not found in $rcPath"
+          }
+          $rcPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build target
         shell: bash
         run: scripts/embedpdf-runtime/build-target.sh "${{ matrix.target }}"

--- a/.github/workflows/release-libpdfium.yml
+++ b/.github/workflows/release-libpdfium.yml
@@ -17,59 +17,21 @@ permissions:
   contents: read
 
 jobs:
-  source-tests:
-    name: Source tests (Linux x64)
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref || github.ref_name }}
-
-      - name: Install depot_tools
-        shell: bash
-        run: |
-          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$RUNNER_TEMP/depot_tools"
-          echo "$RUNNER_TEMP/depot_tools" >> "$GITHUB_PATH"
-
-      - name: Install Linux base deps
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake clang lld curl g++ pkg-config tar
-
-      - name: Run PDFium unit and embedder tests
-        shell: bash
-        run: scripts/embedpdf-runtime/test-target.sh linux-x64
-
-      - name: Upload PDFium test results
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: pdfium-source-test-results-linux-x64
-          path: out/embedpdf-runtime-test-results/linux-x64/
-          if-no-files-found: ignore
-
   build:
     name: Build ${{ matrix.target }}
-    needs: source-tests
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { target: linux-x64,        runner: ubuntu-24.04 }
-          - { target: linux-arm64,      runner: ubuntu-24.04 }
-          - { target: linuxmusl-x64,    runner: ubuntu-24.04 }
-          - { target: linuxmusl-arm64,  runner: ubuntu-24.04 }
-          - { target: wasm32,           runner: ubuntu-24.04 }
-          - { target: darwin-arm64,     runner: macos-15 }
-          - { target: darwin-x64,       runner: macos-15 }
-          - { target: win32-x64,        runner: windows-2022 }
-          - { target: win32-arm64,      runner: windows-2022 }
-    env:
-      DEPOT_TOOLS_WIN_TOOLCHAIN: 0
-      EMSDK_VERSION: 3.1.72
-      MUSL_URLS: ${{ secrets.MUSL_URL || 'https://more.musl.cc https://musl.cc' }}
+          - { target: arm64-v8a,        runner: ubuntu-24.04 }
+          - { target: armeabi-v7a,      runner: ubuntu-24.04 }
+          - { target: x86,              runner: ubuntu-24.04 }
+          - { target: x86_64,           runner: ubuntu-24.04 }
+          # iOS
+          - { target: ios-arm64,        runner: macos-15 }
+          - { target: ios-simulator-arm64, runner: macos-15 }
+          - { target: ios-simulator-x64,   runner: macos-15 }
     steps:
       - uses: actions/checkout@v6
         with:
@@ -85,71 +47,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake curl g++ pkg-config tar
-      - name: Install aarch64 cross-compiler
-        if: matrix.target == 'linux-arm64'
-        shell: bash
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-      - name: Install musl toolchain
-        if: startsWith(matrix.target, 'linuxmusl-')
-        shell: bash
-        run: |
-          triple=x86_64-linux-musl
-          if [[ "${{ matrix.target }}" == "linuxmusl-arm64" ]]; then
-            triple=aarch64-linux-musl
-          fi
-          archive="$triple-cross.tgz"
-
-          for base_url in $MUSL_URLS; do
-            url="$base_url/$archive"
-            if [[ "$base_url" == *"more.musl.cc"* ]]; then
-              url="$base_url/$triple/$archive"
-            fi
-
-            echo "Downloading $url"
-            if curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 --max-time 300 -o "$archive" "$url"; then
-              tar xzf "$archive"
-              echo "$PWD/$triple-cross/bin" >> "$GITHUB_PATH"
-              exit 0
-            fi
-          done
-
-          echo "Failed to download musl toolchain for $triple" >&2
-          exit 1
-      - name: Install Emscripten
-        if: matrix.target == 'wasm32'
-        shell: bash
-        run: |
-          mkdir -p third_party
-          if [[ -d third_party/emsdk ]]; then
-            git -C third_party/emsdk pull
-          else
-            git clone https://github.com/emscripten-core/emsdk.git third_party/emsdk
-          fi
-          third_party/emsdk/emsdk install "$EMSDK_VERSION"
-          third_party/emsdk/emsdk activate "$EMSDK_VERSION"
-          echo "$PWD/third_party/emsdk/upstream/emscripten" >> "$GITHUB_PATH"
-          echo "$PWD/third_party/emsdk/upstream/bin" >> "$GITHUB_PATH"
       - name: Select Xcode
         if: runner.os == 'macOS'
         shell: bash
-        run: sudo xcode-select -s "/Applications/Xcode_26.0.app"
-      - name: Install Windows deps
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $kitsRoot = 'C:\Program Files (x86)\Windows Kits\10\bin'
-          $sdk = Get-ChildItem $kitsRoot -Directory |
-            Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
-            Sort-Object Name -Descending |
-            Select-Object -First 1
-          if ($null -eq $sdk) {
-            throw "No Windows SDK version directory found in $kitsRoot"
-          }
-          $rcPath = Join-Path $sdk.FullName 'x64'
-          if (!(Test-Path (Join-Path $rcPath 'rc.exe'))) {
-            throw "rc.exe not found in $rcPath"
-          }
-          $rcPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: sudo xcode-select -s "/Applications/Xcode_16.1.app"
       - name: Build target
         shell: bash
         run: scripts/embedpdf-runtime/build-target.sh "${{ matrix.target }}"
@@ -161,10 +62,64 @@ jobs:
           name: libembedpdf-pdf-runtime-${{ matrix.target }}
           path: out/embedpdf-runtime-artifacts/*.tar.gz
 
+  ios-universal:
+    name: Build ios-arm64_x86_64-simulator
+    needs: build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref_name }}
+      - uses: actions/download-artifact@v6
+        with:
+          name: libembedpdf-pdf-runtime-ios-simulator-arm64
+          path: artifacts/ios-simulator-arm64
+      - uses: actions/download-artifact@v6
+        with:
+          name: libembedpdf-pdf-runtime-ios-simulator-x64
+          path: artifacts/ios-simulator-x64
+      - name: Combine iOS simulator libraries
+        shell: bash
+        run: |
+          mkdir -p out/ios-universal/lib
+          
+          # Unpack
+          mkdir -p staging/arm64 staging/x64
+          tar -xzf artifacts/ios-simulator-arm64/*.tar.gz -C staging/arm64
+          tar -xzf artifacts/ios-simulator-x64/*.tar.gz -C staging/x64
+          
+          # Combine with lipo
+          lipo -create staging/arm64/lib/libpdfium.a staging/x64/lib/libpdfium.a -output out/ios-universal/lib/libpdfium.a
+          
+          # Copy headers and other files from one of them
+          mkdir -p out/ios-universal/include out/ios-universal/LICENSES
+          cp -R staging/arm64/include/. out/ios-universal/include/
+          cp -R staging/arm64/LICENSES/. out/ios-universal/LICENSES/
+          cp staging/arm64/args.gn out/ios-universal/args.gn
+          
+          # Write metadata
+          cat > out/ios-universal/BUILD-METADATA.json <<EOF
+          {
+            "name": "embedpdf-pdf-runtime",
+            "target": "ios-arm64_x86_64-simulator",
+            "sha": "$(git rev-parse HEAD)",
+            "createdAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          }
+          EOF
+          
+          # Package
+          mkdir -p out/embedpdf-runtime-artifacts
+          short_sha=$(git rev-parse --short HEAD)
+          tar -czf "out/embedpdf-runtime-artifacts/libembedpdf-pdf-runtime-ios-arm64_x86_64-simulator-$short_sha.tar.gz" -C out/ios-universal .
+      - uses: actions/upload-artifact@v6
+        with:
+          name: libembedpdf-pdf-runtime-ios-arm64_x86_64-simulator
+          path: out/embedpdf-runtime-artifacts/*.tar.gz
+
   release:
     name: Publish release
     runs-on: ubuntu-24.04
-    needs: build
+    needs: [build, ios-universal]
     if: github.event_name == 'workflow_dispatch' && inputs.release == true
     permissions:
       contents: write
@@ -172,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref_name }}
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v6
         with:
           path: artifacts
       - name: Flatten artifacts

--- a/.github/workflows/release-libpdfium.yml
+++ b/.github/workflows/release-libpdfium.yml
@@ -66,6 +66,13 @@ jobs:
           - { target: darwin-x64,       runner: macos-15 }
           - { target: win32-x64,        runner: windows-2022 }
           - { target: win32-arm64,      runner: windows-2022 }
+          - { target: arm64-v8a,        runner: ubuntu-24.04 }
+          - { target: armeabi-v7a,      runner: ubuntu-24.04 }
+          - { target: x86,              runner: ubuntu-24.04 }
+          - { target: x86_64,           runner: ubuntu-24.04 }
+          - { target: ios-arm64,        runner: macos-15 }
+          - { target: ios-simulator-arm64, runner: macos-15 }
+          - { target: ios-simulator-x64,   runner: macos-15 }
     env:
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
       EMSDK_VERSION: 3.1.72
@@ -132,7 +139,7 @@ jobs:
       - name: Select Xcode
         if: runner.os == 'macOS'
         shell: bash
-        run: sudo xcode-select -s "/Applications/Xcode_26.0.app"
+        run: sudo xcode-select -s "/Applications/Xcode_16.1.app"
       - name: Install Windows deps
         if: runner.os == 'Windows'
         shell: pwsh
@@ -161,10 +168,64 @@ jobs:
           name: libembedpdf-pdf-runtime-${{ matrix.target }}
           path: out/embedpdf-runtime-artifacts/*.tar.gz
 
+  ios-universal:
+    name: Build ios-arm64_x86_64-simulator
+    needs: build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref_name }}
+      - uses: actions/download-artifact@v6
+        with:
+          name: libembedpdf-pdf-runtime-ios-simulator-arm64
+          path: artifacts/ios-simulator-arm64
+      - uses: actions/download-artifact@v6
+        with:
+          name: libembedpdf-pdf-runtime-ios-simulator-x64
+          path: artifacts/ios-simulator-x64
+      - name: Combine iOS simulator libraries
+        shell: bash
+        run: |
+          mkdir -p out/ios-universal/lib
+          
+          # Unpack
+          mkdir -p staging/arm64 staging/x64
+          tar -xzf artifacts/ios-simulator-arm64/*.tar.gz -C staging/arm64
+          tar -xzf artifacts/ios-simulator-x64/*.tar.gz -C staging/x64
+          
+          # Combine with lipo
+          lipo -create staging/arm64/lib/libpdfium.a staging/x64/lib/libpdfium.a -output out/ios-universal/lib/libpdfium.a
+          
+          # Copy headers and other files from one of them
+          mkdir -p out/ios-universal/include out/ios-universal/LICENSES
+          cp -R staging/arm64/include/. out/ios-universal/include/
+          cp -R staging/arm64/LICENSES/. out/ios-universal/LICENSES/
+          cp staging/arm64/args.gn out/ios-universal/args.gn
+          
+          # Write metadata
+          cat > out/ios-universal/BUILD-METADATA.json <<EOF
+          {
+            "name": "embedpdf-pdf-runtime",
+            "target": "ios-arm64_x86_64-simulator",
+            "sha": "$(git rev-parse HEAD)",
+            "createdAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          }
+          EOF
+          
+          # Package
+          mkdir -p out/embedpdf-runtime-artifacts
+          short_sha=$(git rev-parse --short HEAD)
+          tar -czf "out/embedpdf-runtime-artifacts/libembedpdf-pdf-runtime-ios-arm64_x86_64-simulator-$short_sha.tar.gz" -C out/ios-universal .
+      - uses: actions/upload-artifact@v6
+        with:
+          name: libembedpdf-pdf-runtime-ios-arm64_x86_64-simulator
+          path: out/embedpdf-runtime-artifacts/*.tar.gz
+
   release:
     name: Publish release
     runs-on: ubuntu-24.04
-    needs: build
+    needs: [build, ios-universal]
     if: github.event_name == 'workflow_dispatch' && inputs.release == true
     permissions:
       contents: write
@@ -172,7 +233,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref_name }}
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v6
         with:
           path: artifacts
       - name: Flatten artifacts

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,50 @@
+name: Sync upstream pdfium
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 6am UTC
+  workflow_dispatch: # Manual trigger from Actions tab
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: android-ios-build
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/embedpdf/pdfium.git
+
+      - name: Fetch upstream
+        run: git fetch upstream
+
+      - name: Check for new commits
+        id: check
+        run: |
+          UPSTREAM_HEAD=$(git rev-parse upstream/embedpdf/main)
+          if git merge-base --is-ancestor "$UPSTREAM_HEAD" HEAD; then
+            echo "up_to_date=true" >> $GITHUB_OUTPUT
+          else
+            echo "up_to_date=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Rebase on upstream
+        if: steps.check.outputs.up_to_date == 'false'
+        run: |
+          git rebase upstream/embedpdf/main || {
+            echo "::error::Rebase failed due to conflicts. Manual resolution required."
+            git rebase --abort
+            exit 1
+          }
+
+      - name: Push rebased changes
+        if: steps.check.outputs.up_to_date == 'false'
+        run: git push origin android-ios-build --force-with-lease

--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@
 *.vcxproj
 *.xcodeproj
 *~
+.idea
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -300,53 +300,55 @@ group("pdfium_unittest_deps") {
   ]
 }
 
-test("pdfium_unittests") {
-  testonly = true
-  sources = [ "testing/unit_test_main.cpp" ]
-  deps = [
-    "core/fdrm:unittests",
-    "core/fpdfapi/edit:unittests",
-    "core/fpdfapi/font:unittests",
-    "core/fpdfapi/page:unittests",
-    "core/fpdfapi/parser:unittests",
-    "core/fpdfapi/render:unittests",
-    "core/fpdfdoc:unittests",
-    "core/fpdftext:unittests",
-    "core/fxcodec:unittests",
-    "core/fxcrt",
-    "core/fxcrt:unittests",
-    "core/fxge:unittests",
-    "fpdfsdk:unittests",
-    "testing:unit_test_support",
-    "testing/image_diff:unittests",
-    "//testing/gmock",
-    "//testing/gtest",
-  ]
-  configs += [ ":pdfium_core_config" ]
-  if (is_android) {
-    use_raw_android_executable = true
-  }
-  if (pdf_enable_v8) {
-    configs += [ "//v8:external_startup_data" ]
-    deps += [
-      "fxjs:unittests",
-      "//v8",
+if (!is_ios) {
+  test("pdfium_unittests") {
+    testonly = true
+    sources = [ "testing/unit_test_main.cpp" ]
+    deps = [
+      "core/fdrm:unittests",
+      "core/fpdfapi/edit:unittests",
+      "core/fpdfapi/font:unittests",
+      "core/fpdfapi/page:unittests",
+      "core/fpdfapi/parser:unittests",
+      "core/fpdfapi/render:unittests",
+      "core/fpdfdoc:unittests",
+      "core/fpdftext:unittests",
+      "core/fxcodec:unittests",
+      "core/fxcrt",
+      "core/fxcrt:unittests",
+      "core/fxge:unittests",
+      "fpdfsdk:unittests",
+      "testing:unit_test_support",
+      "testing/image_diff:unittests",
+      "//testing/gmock",
+      "//testing/gtest",
     ]
-    if (pdf_enable_xfa) {
+    configs += [ ":pdfium_core_config" ]
+    if (is_android) {
+      use_raw_android_executable = true
+    }
+    if (pdf_enable_v8) {
+      configs += [ "//v8:external_startup_data" ]
       deps += [
-        "core/fxcrt/css:unittests",
-        "fxbarcode:unittests",
-        "xfa/fde:unittests",
-        "xfa/fgas/crt:unittests",
-        "xfa/fgas/font:unittests",
-        "xfa/fgas/layout:unittests",
-        "xfa/fxfa:unittests",
-        "xfa/fxfa/formcalc:unittests",
-        "xfa/fxfa/parser:unittests",
+        "fxjs:unittests",
+        "//v8",
       ]
+      if (pdf_enable_xfa) {
+        deps += [
+          "core/fxcrt/css:unittests",
+          "fxbarcode:unittests",
+          "xfa/fde:unittests",
+          "xfa/fgas/crt:unittests",
+          "xfa/fgas/font:unittests",
+          "xfa/fgas/layout:unittests",
+          "xfa/fxfa:unittests",
+          "xfa/fxfa/formcalc:unittests",
+          "xfa/fxfa/parser:unittests",
+        ]
+      }
     }
   }
-}
+}  # !is_ios
 
 group("pdfium_embeddertest_deps") {
   testonly = true
@@ -365,49 +367,51 @@ group("pdfium_embeddertest_deps") {
   ]
 }
 
-test("pdfium_embeddertests") {
-  testonly = true
-  sources = [ "testing/embedder_test_main.cpp" ]
-  deps = [
-    ":pdfium_embeddertest_deps",
-    "core/fpdfapi/edit:embeddertests",
-    "core/fpdfapi/parser:embeddertests",
-    "core/fpdfapi/render:embeddertests",
-    "core/fxcodec:embeddertests",
-    "core/fxcrt",
-    "core/fxge:embeddertests",
-    "fpdfsdk:embeddertests",
-    "fpdfsdk/formfiller:embeddertests",
-    "fpdfsdk/pwl:embeddertests",
-    "testing/image_diff",
-    "//testing/gmock",
-    "//testing/gtest",
-  ]
-  include_dirs = [ "testing/gmock/include" ]
-  configs += [ ":pdfium_core_config" ]
-
-  if (is_android) {
-    ignore_all_data_deps = true
-    use_raw_android_executable = true
-  }
-
-  if (pdf_enable_v8) {
-    deps += [
-      "fxjs:embeddertests",
-      "//v8",
+if (!is_ios) {
+  test("pdfium_embeddertests") {
+    testonly = true
+    sources = [ "testing/embedder_test_main.cpp" ]
+    deps = [
+      ":pdfium_embeddertest_deps",
+      "core/fpdfapi/edit:embeddertests",
+      "core/fpdfapi/parser:embeddertests",
+      "core/fpdfapi/render:embeddertests",
+      "core/fxcodec:embeddertests",
+      "core/fxcrt",
+      "core/fxge:embeddertests",
+      "fpdfsdk:embeddertests",
+      "fpdfsdk/formfiller:embeddertests",
+      "fpdfsdk/pwl:embeddertests",
+      "testing/image_diff",
+      "//testing/gmock",
+      "//testing/gtest",
     ]
-    configs += [ "//v8:external_startup_data" ]
-  }
+    include_dirs = [ "testing/gmock/include" ]
+    configs += [ ":pdfium_core_config" ]
 
-  if (pdf_enable_xfa) {
-    deps += [
-      "fpdfsdk/fpdfxfa:embeddertests",
-      "xfa/fwl:embeddertests",
-      "xfa/fxfa/layout:embeddertests",
-      "xfa/fxfa/parser:embeddertests",
-    ]
+    if (is_android) {
+      ignore_all_data_deps = true
+      use_raw_android_executable = true
+    }
+
+    if (pdf_enable_v8) {
+      deps += [
+        "fxjs:embeddertests",
+        "//v8",
+      ]
+      configs += [ "//v8:external_startup_data" ]
+    }
+
+    if (pdf_enable_xfa) {
+      deps += [
+        "fpdfsdk/fpdfxfa:embeddertests",
+        "xfa/fwl:embeddertests",
+        "xfa/fxfa/layout:embeddertests",
+        "xfa/fxfa/parser:embeddertests",
+      ]
+    }
   }
-}
+}  # !is_ios
 
 executable("pdfium_diff") {
   visibility += [ "testing/tools:test_runner_py" ]
@@ -427,11 +431,16 @@ group("pdfium_all") {
   testonly = true
   deps = [
     ":pdfium_diff",
-    ":pdfium_embeddertests",
-    ":pdfium_unittests",
     "testing:pdfium_test",
     "testing/fuzzers",
   ]
+
+  if (!is_ios) {
+    deps += [
+      ":pdfium_embeddertests",
+      ":pdfium_unittests",
+    ]
+  }
 
   if (pdf_is_standalone) {
     deps += [ "testing/tools:test_runner_py" ]

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -50,8 +50,9 @@ if (use_system_xcode == "") {
                           [ target_os ],
                           "value")
     use_system_xcode = _result == 0
-  }
-  if (target_os == "ios") {
+  } else if (target_os == "ios") {
+    use_system_xcode = true
+  } else {
     use_system_xcode = true
   }
 }

--- a/core/fxge/BUILD.gn
+++ b/core/fxge/BUILD.gn
@@ -166,7 +166,7 @@ source_set("fxge") {
     sources += [ "linux/fx_linux_impl.cpp" ]
   }
 
-  if (is_mac) {
+  if (is_mac || is_ios) {
     sources += [
       "apple/fx_apple_impl.cpp",
       "apple/fx_apple_platform.cpp",

--- a/patches/embedpdf-runtime/android/build.patch
+++ b/patches/embedpdf-runtime/android/build.patch
@@ -1,0 +1,35 @@
+diff --git a/config/BUILDCONFIG.gn b/config/BUILDCONFIG.gn
+index b5dca4a..279e0ab 100644
+--- a/config/BUILDCONFIG.gn
++++ b/config/BUILDCONFIG.gn
+@@ -241,7 +241,7 @@ _default_toolchain = ""
+ 
+ if (target_os == "android") {
+   # Targeting android on Mac is best-effort and not guaranteed to work.
+-  assert(host_os == "linux", "Android builds are only supported on Linux.")
++  assert(host_os == "linux" || host_os == "mac", "Android builds are only supported on Linux or Mac.")
+   _default_toolchain = "//build/toolchain/android:android_clang_$target_cpu"
+ } else if (target_os == "chromeos" || target_os == "linux") {
+   # See comments in build/toolchain/cros/BUILD.gn about board compiles.
+diff --git a/config/android/config.gni b/config/android/config.gni
+index cc12ce7..392e125 100644
+--- a/config/android/config.gni
++++ b/config/android/config.gni
+@@ -69,7 +69,7 @@ if (is_android) {
+ 
+     # The default to use for android:minSdkVersion for targets that do
+     # not explicitly set it.
+-    default_min_sdk_version = 29
++    default_min_sdk_version = 21
+     if (is_cronet_build) {
+       # Cronet's min sdk version support policy is different from the rest of
+       # Chromium; Cronet explicitly supports older devices.
+@@ -131,7 +131,7 @@ if (is_android) {
+   }
+ 
+   # Our build system no longer supports legacy multidex.
+-  min_supported_sdk_version = 23
++  min_supported_sdk_version = 21
+ 
+   # ASAN requires O MR1.
+   # https://github.com/google/sanitizers/wiki/AddressSanitizerOnAndroid/01f8df1ac1a447a8475cdfcb03e8b13140042dbd#running-with-wrapsh-recommended

--- a/patches/embedpdf-runtime/ios/libcxx_config_site.patch
+++ b/patches/embedpdf-runtime/ios/libcxx_config_site.patch
@@ -1,0 +1,14 @@
+diff --git a/__config_site b/__config_site
+index 1234567..abcdefg 100644
+--- a/__config_site
++++ b/__config_site
+@@ -16,9 +16,9 @@
+ //    limit for PDBs (https://crbug.com/1327710#c5). To fix this, we set
+ //    _LIBCPP_ABI_NAMESPACE to a shorter value.
+-#define _LIBCPP_ABI_NAMESPACE __Cr
++#define _LIBCPP_ABI_NAMESPACE __1
+ 
+-#define _LIBCPP_ABI_VERSION 2
++#define _LIBCPP_ABI_VERSION 1
+ 
+ #define _LIBCPP_ABI_FORCE_ITANIUM 0

--- a/patches/embedpdf-runtime/ios/libjpeg_turbo.patch
+++ b/patches/embedpdf-runtime/ios/libjpeg_turbo.patch
@@ -1,0 +1,17 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 7e5ca70..3708d7a 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -11,9 +11,9 @@ if (current_cpu == "arm" || current_cpu == "arm64") {
+   import("//build/config/arm.gni")
+ }
+ 
+-assert(
+-    use_blink,
+-    "This is not used if blink is not enabled, don't drag it in unintentionally")
++# assert(
++#     use_blink,
++#     "This is not used if blink is not enabled, don't drag it in unintentionally")
+ 
+ source_set("libjpeg_headers") {
+   sources = [

--- a/patches/embedpdf-runtime/shared-library.patch
+++ b/patches/embedpdf-runtime/shared-library.patch
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 62210c2f6..053fbff6d 100644
+index fbdb13a4e..3b450b979 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -228,7 +228,7 @@ group("pdfium_public_headers") {
+@@ -225,10 +225,18 @@ group("pdfium_public_headers") {
    ]
  }
  
@@ -11,7 +11,18 @@ index 62210c2f6..053fbff6d 100644
    output_name = "pdfium"
    libs = []
    configs += [ ":pdfium_strict_config" ]
-@@ -263,6 +263,9 @@ component("pdfium") {
++  if (is_android) {
++    _configs = filter_exclude(configs, [
++      "//build/config/android:hide_all_but_jni_onload",
++      "//build/config/android:hide_all_but_jni",
++    ])
++    configs = []
++    configs = _configs
++  }
+   public_configs = [ ":pdfium_public_config" ]
+ 
+   deps = [
+@@ -263,6 +269,9 @@ component("pdfium") {
        "gdi32.lib",
        "user32.lib",
      ]

--- a/scripts/embedpdf-runtime/apply-patches.sh
+++ b/scripts/embedpdf-runtime/apply-patches.sh
@@ -94,6 +94,7 @@ case "$TARGET" in
     ;;
   ios-*)
     apply_patch_file "$SOURCE_DIR/third_party/libjpeg_turbo" "$PATCH_DIR/ios/libjpeg_turbo.patch"
+    apply_patch_file "$SOURCE_DIR/buildtools/third_party/libc++" "$PATCH_DIR/ios/libcxx_config_site.patch"
     ;;
   *)
     echo "unknown target: $TARGET" >&2

--- a/scripts/embedpdf-runtime/apply-patches.sh
+++ b/scripts/embedpdf-runtime/apply-patches.sh
@@ -88,6 +88,13 @@ case "$TARGET" in
   linux-*)
     apply_patch_file "$SOURCE_DIR" "$PATCH_DIR/shared-library.patch"
     ;;
+  android-* | arm64-v8a | armeabi-v7a | x86 | x86_64)
+    apply_patch_file "$SOURCE_DIR" "$PATCH_DIR/shared-library.patch"
+    apply_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/android/build.patch"
+    ;;
+  ios-*)
+    apply_patch_file "$SOURCE_DIR/third_party/libjpeg_turbo" "$PATCH_DIR/ios/libjpeg_turbo.patch"
+    ;;
   *)
     echo "unknown target: $TARGET" >&2
     exit 1

--- a/scripts/embedpdf-runtime/build-target.sh
+++ b/scripts/embedpdf-runtime/build-target.sh
@@ -57,6 +57,44 @@ case "$TARGET" in
     GN_TARGET_CPU="arm64"
     PDF_IS_COMPLETE_LIB=false
     ;;
+  android-arm64 | arm64-v8a)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="arm64"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  android-arm | armeabi-v7a)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="arm"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  android-x64 | x86_64)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="x64"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  android-x86 | x86)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="x86"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  ios-arm64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="arm64"
+    PDF_IS_COMPLETE_LIB=true
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\ntarget_environment="device"'
+    ;;
+  ios-simulator-arm64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="arm64"
+    PDF_IS_COMPLETE_LIB=true
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\nuse_ios_simulator=true\ntarget_environment="simulator"'
+    ;;
+  ios-simulator-x64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="x64"
+    PDF_IS_COMPLETE_LIB=true
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\nuse_ios_simulator=true\ntarget_environment="simulator"'
+    ;;
   *)
     echo "unknown target: $TARGET" >&2
     exit 1
@@ -68,12 +106,22 @@ PDF_RUNTIME_TARGET_OS_LIST="${PDF_RUNTIME_TARGET_OS_LIST:-$GN_TARGET_OS}" \
 
 "$SOURCE_DIR/scripts/embedpdf-runtime/apply-patches.sh" "$TARGET"
 
-if [[ "$TARGET" == linux-* ]]; then
-  (
-    cd "$SOURCE_DIR"
-    build/install-build-deps.sh --no-prompt
-    build/linux/sysroot_scripts/install-sysroot.py "--arch=$GN_TARGET_CPU"
-  )
+if [[ "$(uname)" == "Linux" ]]; then
+  if [[ "$TARGET" == linux-* || "$TARGET" == android-* || "$TARGET" == arm64-v8a || "$TARGET" == armeabi-v7a || "$TARGET" == x86 || "$TARGET" == x86_64 ]]; then
+    (
+      cd "$SOURCE_DIR"
+      if [[ "$TARGET" == android-* || "$TARGET" == arm64-v8a || "$TARGET" == armeabi-v7a || "$TARGET" == x86 || "$TARGET" == x86_64 ]]; then
+         # For android, we might need --android but it's often slow and interactive.
+         # Most runners have what's needed. Let's try without --android first but keep the base linux deps.
+         build/install-build-deps.sh --no-prompt --no-arm --no-chromeos-fonts
+      else
+         build/install-build-deps.sh --no-prompt
+      fi
+      if [[ "$GN_TARGET_OS" == "linux" ]]; then
+        build/linux/sysroot_scripts/install-sysroot.py "--arch=$GN_TARGET_CPU"
+      fi
+    )
+  fi
 fi
 
 OUT="$SOURCE_DIR/out/embedpdf-runtime/$TARGET"

--- a/scripts/embedpdf-runtime/build-target.sh
+++ b/scripts/embedpdf-runtime/build-target.sh
@@ -57,6 +57,44 @@ case "$TARGET" in
     GN_TARGET_CPU="arm64"
     PDF_IS_COMPLETE_LIB=false
     ;;
+  android-arm64 | arm64-v8a)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="arm64"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  android-arm | armeabi-v7a)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="arm"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  android-x64 | x86_64)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="x64"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  android-x86 | x86)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="x86"
+    PDF_IS_COMPLETE_LIB=false
+    ;;
+  ios-arm64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="arm64"
+    PDF_IS_COMPLETE_LIB=true
+    EXTRA_ARGS=$'\nios_enable_code_signing=false'
+    ;;
+  ios-simulator-arm64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="arm64"
+    PDF_IS_COMPLETE_LIB=true
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\nuse_ios_simulator=true'
+    ;;
+  ios-simulator-x64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="x64"
+    PDF_IS_COMPLETE_LIB=true
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\nuse_ios_simulator=true'
+    ;;
   *)
     echo "unknown target: $TARGET" >&2
     exit 1
@@ -68,11 +106,19 @@ PDF_RUNTIME_TARGET_OS_LIST="${PDF_RUNTIME_TARGET_OS_LIST:-$GN_TARGET_OS}" \
 
 "$SOURCE_DIR/scripts/embedpdf-runtime/apply-patches.sh" "$TARGET"
 
-if [[ "$TARGET" == linux-* ]]; then
+if [[ "$TARGET" == linux-* || "$TARGET" == android-* || "$TARGET" == arm64-v8a || "$TARGET" == armeabi-v7a || "$TARGET" == x86 || "$TARGET" == x86_64 ]]; then
   (
     cd "$SOURCE_DIR"
-    build/install-build-deps.sh --no-prompt
-    build/linux/sysroot_scripts/install-sysroot.py "--arch=$GN_TARGET_CPU"
+    if [[ "$TARGET" == android-* || "$TARGET" == arm64-v8a || "$TARGET" == armeabi-v7a || "$TARGET" == x86 || "$TARGET" == x86_64 ]]; then
+       # For android, we might need --android but it's often slow and interactive.
+       # Most runners have what's needed. Let's try without --android first but keep the base linux deps.
+       build/install-build-deps.sh --no-prompt --no-arm --no-chromeos-fonts
+    else
+       build/install-build-deps.sh --no-prompt
+    fi
+    if [[ "$GN_TARGET_OS" == "linux" ]]; then
+      build/linux/sysroot_scripts/install-sysroot.py "--arch=$GN_TARGET_CPU"
+    fi
   )
 fi
 

--- a/scripts/embedpdf-runtime/package-ios-simulator-universal.sh
+++ b/scripts/embedpdf-runtime/package-ios-simulator-universal.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="${PDF_RUNTIME_SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+ARTIFACT_DIR="${PDF_RUNTIME_ARTIFACT_DIR:-$SOURCE_DIR/out/embedpdf-runtime-artifacts}"
+
+# This script combines ios-simulator-arm64 and ios-simulator-x64 into a single
+# universal library and packages it. It expects that both targets have already
+# been built and packaged with package-target.sh.
+
+STAGING="$SOURCE_DIR/out/embedpdf-runtime-staging/ios-simulator-universal"
+mkdir -p "$STAGING"
+
+# Find the latest artifacts for both targets
+ARM64_ARTIFACT=$(ls -t "$ARTIFACT_DIR"/libembedpdf-pdf-runtime-ios-simulator-arm64-*.tar.gz 2>/dev/null | head -n 1 || true)
+X64_ARTIFACT=$(ls -t "$ARTIFACT_DIR"/libembedpdf-pdf-runtime-ios-simulator-x64-*.tar.gz 2>/dev/null | head -n 1 || true)
+
+if [[ -z "$ARM64_ARTIFACT" || -z "$X64_ARTIFACT" ]]; then
+  echo "Error: Missing required artifacts for ios-simulator-arm64 and/or ios-simulator-x64" >&2
+  exit 1
+fi
+
+echo "Combining artifacts:"
+echo "  $ARM64_ARTIFACT"
+echo "  $X64_ARTIFACT"
+
+TMP_ARM64="$STAGING/arm64"
+TMP_X64="$STAGING/x64"
+mkdir -p "$TMP_ARM64" "$TMP_X64"
+
+tar -xzf "$ARM64_ARTIFACT" -C "$TMP_ARM64"
+tar -xzf "$X64_ARTIFACT" -C "$TMP_X64"
+
+# Combine with lipo
+mkdir -p "$STAGING/lib"
+lipo -create "$TMP_ARM64/lib/libpdfium.a" "$TMP_X64/lib/libpdfium.a" -output "$STAGING/lib/libpdfium.a"
+
+# Copy headers and other metadata from arm64 (they should be identical)
+cp -R "$TMP_ARM64/include" "$STAGING/include"
+cp "$TMP_ARM64/args.gn" "$STAGING/args.gn"
+if [[ -d "$TMP_ARM64/LICENSES" ]]; then
+  cp -R "$TMP_ARM64/LICENSES" "$STAGING/LICENSES"
+fi
+
+# Write metadata
+cat > "$STAGING/BUILD-METADATA.json" <<EOF
+{
+  "name": "embedpdf-pdf-runtime",
+  "target": "ios-arm64_x86_64-simulator",
+  "sha": "$(git -C "$SOURCE_DIR" rev-parse HEAD)",
+  "createdAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+
+# Package
+SHORT_SHA=$(git -C "$SOURCE_DIR" rev-parse --short HEAD)
+OUT_FILE="$ARTIFACT_DIR/libembedpdf-pdf-runtime-ios-arm64_x86_64-simulator-$SHORT_SHA.tar.gz"
+mkdir -p "$(dirname "$OUT_FILE")"
+tar -czf "$OUT_FILE" -C "$STAGING" .
+
+echo "Created universal artifact: $OUT_FILE"

--- a/scripts/embedpdf-runtime/package-target.sh
+++ b/scripts/embedpdf-runtime/package-target.sh
@@ -27,11 +27,11 @@ case "$TARGET" in
     LIB_SOURCE="$OUT/libpdfium.dylib"
     LIB_DEST="$STAGING/lib/libpdfium.dylib"
     ;;
-  linux-*)
+  linux-*|android-*|arm64-v8a|armeabi-v7a|x86_64|x86)
     LIB_SOURCE="$OUT/libpdfium.so"
     LIB_DEST="$STAGING/lib/libpdfium.so"
     ;;
-  linuxmusl-*|wasm32)
+  ios-*|linuxmusl-*|wasm32)
     LIB_SOURCE="$OUT/obj/libpdfium.a"
     LIB_DEST="$STAGING/lib/libpdfium.a"
     ;;

--- a/scripts/embedpdf-runtime/sync-deps.sh
+++ b/scripts/embedpdf-runtime/sync-deps.sh
@@ -31,6 +31,8 @@ solutions = [
     "managed": False,
     "custom_vars": {
       "checkout_configuration": "small",
+      $( [[ "$TARGET_OS_LIST" == *"android"* ]] && echo '"checkout_android": True,' )
+      $( [[ "$TARGET_OS_LIST" == *"ios"* ]] && echo '"checkout_ios": True,' )
     },
   },
 ]

--- a/scripts/embedpdf-runtime/sync-deps.sh
+++ b/scripts/embedpdf-runtime/sync-deps.sh
@@ -31,6 +31,7 @@ solutions = [
     "managed": False,
     "custom_vars": {
       "checkout_configuration": "small",
+      $( [[ "$TARGET_OS_LIST" == *"android"* ]] && echo '"checkout_android": True,' )
     },
   },
 ]

--- a/scripts/embedpdf-runtime/test-target.sh
+++ b/scripts/embedpdf-runtime/test-target.sh
@@ -116,6 +116,14 @@ target_cpu="$GN_TARGET_CPU"${EXTRA_ARGS:-}
 EOF
 
 targets=()
+
+# iOS builds skip tests entirely (test targets are excluded from the iOS build).
+if [[ "$GN_TARGET_OS" == "ios" ]]; then
+  echo "=== tests are not supported on iOS, skipping ==="
+  echo "$RESULTS"
+  exit 0
+fi
+
 case "$TEST_SUITE" in
   all)
     targets+=(pdfium_unittests pdfium_embeddertests)

--- a/scripts/embedpdf-runtime/test-target.sh
+++ b/scripts/embedpdf-runtime/test-target.sh
@@ -36,8 +36,39 @@ case "$TARGET" in
     GN_TARGET_CPU="arm64"
     EXTRA_ARGS=$'\narm_control_flow_integrity="none"'
     ;;
+  android-arm64 | arm64-v8a)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="arm64"
+    ;;
+  android-arm | armeabi-v7a)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="arm"
+    ;;
+  android-x64 | x86_64)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="x64"
+    ;;
+  android-x86 | x86)
+    GN_TARGET_OS="android"
+    GN_TARGET_CPU="x86"
+    ;;
+  ios-arm64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="arm64"
+    EXTRA_ARGS=$'\nios_enable_code_signing=false'
+    ;;
+  ios-simulator-arm64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="arm64"
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\nuse_ios_simulator=true'
+    ;;
+  ios-simulator-x64)
+    GN_TARGET_OS="ios"
+    GN_TARGET_CPU="x64"
+    EXTRA_ARGS=$'\nios_enable_code_signing=false\nuse_ios_simulator=true'
+    ;;
   *)
-    echo "test-target.sh only supports host-native targets: darwin-arm64, darwin-x64, linux-x64, linux-arm64" >&2
+    echo "test-target.sh only supports host-native and cross-buildable targets: darwin-arm64, darwin-x64, linux-x64, linux-arm64, android-*, ios-*" >&2
     exit 1
     ;;
 esac
@@ -47,11 +78,19 @@ PDF_RUNTIME_TARGET_OS_LIST="${PDF_RUNTIME_TARGET_OS_LIST:-$GN_TARGET_OS}" \
 
 "$SOURCE_DIR/scripts/embedpdf-runtime/apply-patches.sh" "$TARGET"
 
-if [[ "$TARGET" == linux-* ]]; then
+if [[ "$TARGET" == linux-* || "$TARGET" == android-* || "$TARGET" == arm64-v8a || "$TARGET" == armeabi-v7a || "$TARGET" == x86 || "$TARGET" == x86_64 ]]; then
   (
     cd "$SOURCE_DIR"
-    build/install-build-deps.sh --no-prompt
-    build/linux/sysroot_scripts/install-sysroot.py "--arch=$GN_TARGET_CPU"
+    if [[ "$TARGET" == android-* || "$TARGET" == arm64-v8a || "$TARGET" == armeabi-v7a || "$TARGET" == x86 || "$TARGET" == x86_64 ]]; then
+       # For android, we might need --android but it's often slow and interactive.
+       # Most runners have what's needed. Let's try without --android first but keep the base linux deps.
+       build/install-build-deps.sh --no-prompt --no-arm --no-chromeos-fonts
+    else
+       build/install-build-deps.sh --no-prompt
+    fi
+    if [[ "$GN_TARGET_OS" == "linux" ]]; then
+      build/linux/sysroot_scripts/install-sysroot.py "--arch=$GN_TARGET_CPU"
+    fi
   )
 fi
 
@@ -112,6 +151,12 @@ run_gtest() {
     # Do not use this for arguments containing spaces.
     extra_gtest_args=($PDFIUM_GTEST_ARGS)
     cmd+=("${extra_gtest_args[@]}")
+  fi
+
+  if [[ "$GN_TARGET_OS" == "android" || "$GN_TARGET_OS" == "ios" ]]; then
+    echo "=== building $binary (execution skipped on $GN_TARGET_OS) ==="
+    # We already built it with ninja, so we just exit here.
+    return 0
   fi
 
   echo "=== running $binary ==="

--- a/scripts/embedpdf-runtime/unapply-patches.sh
+++ b/scripts/embedpdf-runtime/unapply-patches.sh
@@ -65,6 +65,8 @@ reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/win/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/mac/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/wasm/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/musl/build.patch"
+reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/android/build.patch"
+reverse_patch_file "$SOURCE_DIR/third_party/libjpeg_turbo" "$PATCH_DIR/ios/libjpeg_turbo.patch"
 reverse_patch_file "$SOURCE_DIR" "$PATCH_DIR/musl/pdfium.patch"
 reverse_patch_file "$SOURCE_DIR" "$PATCH_DIR/shared-library.patch"
 

--- a/scripts/embedpdf-runtime/unapply-patches.sh
+++ b/scripts/embedpdf-runtime/unapply-patches.sh
@@ -67,6 +67,7 @@ reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/wasm/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/musl/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/android/build.patch"
 reverse_patch_file "$SOURCE_DIR/third_party/libjpeg_turbo" "$PATCH_DIR/ios/libjpeg_turbo.patch"
+reverse_patch_file "$SOURCE_DIR/buildtools/third_party/libc++" "$PATCH_DIR/ios/libcxx_config_site.patch"
 reverse_patch_file "$SOURCE_DIR" "$PATCH_DIR/musl/pdfium.patch"
 reverse_patch_file "$SOURCE_DIR" "$PATCH_DIR/shared-library.patch"
 

--- a/testing/test.gni
+++ b/testing/test.gni
@@ -11,6 +11,10 @@
 # Variable:
 #   use_raw_android_executable: Use executable() rather than android_apk().
 #   use_native_activity: Test implements ANativeActivity_onCreate().
+declare_args() {
+  ios_automatically_manage_certs = true
+}
+
 template("test") {
   if (is_android) {
     import("//build/config/android/config.gni")


### PR DESCRIPTION
This PR adds build support for Android and iOS targets (including compiling and patching libjpeg_turbo for iOS), and restores all previous desktop (Linux, macOS, Windows) and WebAssembly targets in the release workflow.