### PR TITLE
Add annotation key removal API

### DIFF
--- a/fpdfsdk/fpdf_annot.cpp
+++ b/fpdfsdk/fpdf_annot.cpp
@@ -2775,6 +2775,18 @@ EPDFAnnot_RemoveDest(FPDF_ANNOTATION annot) {
   return RemoveLinkDictEntry(annot, "Dest");
 }
 
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAnnot_RemoveKey(FPDF_ANNOTATION annot, FPDF_BYTESTRING key) {
+  RetainPtr<CPDF_Dictionary> annot_dict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict || !key) {
+    return false;
+  }
+
+  annot_dict->RemoveFor(key);
+  return true;
+}
+
 FPDF_EXPORT FPDF_ATTACHMENT FPDF_CALLCONV
 FPDFAnnot_GetFileAttachment(FPDF_ANNOTATION annot) {
   if (FPDFAnnot_GetSubtype(annot) != FPDF_ANNOT_FILEATTACHMENT) {

--- a/fpdfsdk/fpdf_annot_embeddertest.cpp
+++ b/fpdfsdk/fpdf_annot_embeddertest.cpp
@@ -3276,6 +3276,80 @@ TEST_F(FPDFAnnotEmbedderTest, Bug1212) {
   }
 }
 
+TEST_F(FPDFAnnotEmbedderTest, RemoveKey) {
+  ASSERT_TRUE(OpenDocument("hello_world.pdf"));
+  ScopedPage page = LoadScopedPage(0);
+  ASSERT_TRUE(page);
+  EXPECT_EQ(0, FPDFPage_GetAnnotCount(page.get()));
+
+  static const char kStateKey[] = "State";
+  static const char kStateModelKey[] = "StateModel";
+  static const wchar_t kState[] = L"Accepted";
+  static const wchar_t kStateModel[] = L"Review";
+  static const size_t kBufSize = 32;
+  std::vector<FPDF_WCHAR> buf = GetFPDFWideStringBuffer(kBufSize);
+
+  {
+    // A review-status reply per ISO 32000-2 12.5.6.3: a text annotation
+    // carrying /State + /StateModel.
+    ScopedFPDFAnnotation annot(
+        FPDFPage_CreateAnnot(page.get(), FPDF_ANNOT_TEXT));
+    ASSERT_TRUE(annot);
+
+    ScopedFPDFWideString state = GetFPDFWideString(kState);
+    ScopedFPDFWideString model = GetFPDFWideString(kStateModel);
+    EXPECT_TRUE(FPDFAnnot_SetStringValue(annot.get(), kStateKey, state.get()));
+    EXPECT_TRUE(
+        FPDFAnnot_SetStringValue(annot.get(), kStateModelKey, model.get()));
+
+    std::ranges::fill(buf, 'x');
+    ASSERT_EQ(18u, FPDFAnnot_GetStringValue(annot.get(), kStateKey, buf.data(),
+                                            kBufSize));
+    EXPECT_EQ(kState, GetPlatformWString(buf.data()));
+
+    // Overwriting with an empty string is NOT removal: the entry stays.
+    ScopedFPDFWideString empty = GetFPDFWideString(L"");
+    EXPECT_TRUE(FPDFAnnot_SetStringValue(annot.get(), kStateKey, empty.get()));
+    EXPECT_TRUE(FPDFAnnot_HasKey(annot.get(), kStateKey));
+
+    // RemoveKey truly removes the entry.
+    EXPECT_TRUE(EPDFAnnot_RemoveKey(annot.get(), kStateKey));
+    EXPECT_FALSE(FPDFAnnot_HasKey(annot.get(), kStateKey));
+    std::ranges::fill(buf, 'x');
+    ASSERT_EQ(2u, FPDFAnnot_GetStringValue(annot.get(), kStateKey, buf.data(),
+                                           kBufSize));
+    EXPECT_EQ(L"", GetPlatformWString(buf.data()));
+
+    // Idempotent on an absent key; false only on null inputs.
+    EXPECT_TRUE(EPDFAnnot_RemoveKey(annot.get(), kStateKey));
+    EXPECT_FALSE(EPDFAnnot_RemoveKey(nullptr, kStateKey));
+    EXPECT_FALSE(EPDFAnnot_RemoveKey(annot.get(), nullptr));
+
+    // /StateModel is untouched by the /State removal.
+    EXPECT_TRUE(FPDFAnnot_HasKey(annot.get(), kStateModelKey));
+  }
+
+  // The removal survives a save/reopen round trip.
+  EXPECT_TRUE(FPDF_SaveAsCopy(document(), this, 0));
+
+  {
+    ScopedSavedDoc saved_doc = OpenScopedSavedDocument();
+    ASSERT_TRUE(saved_doc);
+    ScopedSavedPage saved_page = LoadScopedSavedPage(0);
+    ASSERT_TRUE(saved_page);
+
+    EXPECT_EQ(1, FPDFPage_GetAnnotCount(saved_page.get()));
+    ScopedFPDFAnnotation annot(FPDFPage_GetAnnot(saved_page.get(), 0));
+    ASSERT_TRUE(annot);
+
+    EXPECT_FALSE(FPDFAnnot_HasKey(annot.get(), kStateKey));
+    std::ranges::fill(buf, 'x');
+    ASSERT_EQ(14u, FPDFAnnot_GetStringValue(annot.get(), kStateModelKey,
+                                            buf.data(), kBufSize));
+    EXPECT_EQ(kStateModel, GetPlatformWString(buf.data()));
+  }
+}
+
 TEST_F(FPDFAnnotEmbedderTest, GetOptionCountCombobox) {
   // Open a file with combobox widget annotations and load its first page.
   ASSERT_TRUE(OpenDocument("combobox_form.pdf"));

--- a/public/fpdf_annot.h
+++ b/public/fpdf_annot.h
@@ -1750,6 +1750,27 @@ FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV EPDFAnnot_RemoveAction(FPDF_ANNOTATION annot
 FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV EPDFAnnot_RemoveDest(FPDF_ANNOTATION annot);
 
 // Experimental EmbedPDF Extension API.
+// Remove |key| from |annot|'s dictionary.
+//
+//   annot - handle to an annotation.
+//   key   - the key to remove, encoded in UTF-8.
+//
+// Returns true when the entry is absent afterwards, including when there
+// was none to begin with (idempotent). False on a null |annot| or |key|.
+//
+// Notes:
+//  * Generic top-level entry removal, completing the FPDFAnnot_HasKey /
+//    FPDFAnnot_GetValueType / FPDFAnnot_SetStringValue family. Passing a
+//    NULL value to FPDFAnnot_SetStringValue writes an EMPTY string; this
+//    function is the only way to truly remove an entry (e.g. /State,
+//    /StateModel, /Subj, /Contents).
+//  * Like FPDFAnnot_SetStringValue, no key is off-limits — removing a
+//    structural entry (/Subtype, /Rect) produces a malformed annotation.
+//    Callers are expected to know what they are removing.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV EPDFAnnot_RemoveKey(FPDF_ANNOTATION annot,
+                                                        FPDF_BYTESTRING key);
+
+// Experimental EmbedPDF Extension API.
 // Get the annotation count.
 //
 //   doc    - handle to a document.


### PR DESCRIPTION
Adds an experimental EmbedPDF API to remove arbitrary dictionary keys from an annotation via EPDFAnnot_RemoveKey, along with documentation covering its semantics and caveats. Includes embedder tests for removing /State, idempotent behavior, null-argument handling, and persistence across save/reopen.