### PR TITLE
Add action model targets and payload limits

### DIFF
--- a/fpdfsdk/epdf_action.cpp
+++ b/fpdfsdk/epdf_action.cpp
@@ -34,6 +34,21 @@ namespace {
 constexpr size_t kMaxActionDepth = 64;
 constexpr size_t kMaxActionNodes = 1024;
 constexpr size_t kMaxJavaScriptCodeUnits = 8 * 1024 * 1024;
+// Hide /T + ResetForm /Fields entries, cumulative across one model.
+constexpr size_t kMaxActionTargets = 2048;
+// URI, file path, named-action, named-destination, and target-name bytes,
+// cumulative across one model.
+constexpr size_t kMaxActionPayloadBytes = 1 << 20;
+// FPDFDest reads at most the page, the view name, and four view parameters;
+// destination array elements beyond that carry no meaning.
+constexpr size_t kMaxDestinationElements = 6;
+
+struct ActionTargetRecord {
+  // Exactly one is meaningful: a field FQN (UTF-8) when |object_number| is
+  // 0, otherwise an indirect annotation/field dictionary object number.
+  ByteString name;
+  uint32_t object_number = 0;
+};
 
 struct ActionNodeRecord {
   ByteString subtype;
@@ -44,6 +59,35 @@ struct ActionNodeRecord {
   ByteString uri;
   ByteString file_path;
   ByteString name;
+  // Hide /T or ResetForm /Fields entries. |targets_valid| == false means an
+  // entry could not be represented; a partial target list must never
+  // execute, so the whole list is withheld while the node's siblings and
+  // /Next chain stay usable.
+  std::vector<ActionTargetRecord> targets;
+  bool targets_valid = true;
+  // Hide /H: true hides (the spec default), false shows.
+  bool hide = true;
+  // ResetForm: whether /Fields was PRESENT. Absent means "reset every
+  // field" and |exclude| is meaningless — presence and emptiness are
+  // different states (PDFium's executor branches on HasFields() first).
+  bool reset_has_fields = false;
+  // ResetForm /Flags bit 0: set = /Fields lists EXCLUDED fields.
+  bool exclude = false;
+  // URI /IsMap.
+  bool is_map = false;
+  // SubmitForm /F resolved to a URL (UTF-8). |submit_url_valid| == false
+  // means the REQUIRED /F was absent, not a URL file specification, or
+  // unrepresentable — the payload is withheld so the reader degrades the
+  // node instead of executing a half payload.
+  ByteString submit_url;
+  bool submit_url_valid = false;
+  // SubmitForm raw /Flags word (ISO 32000-2 Table 240, bits numbered from 1).
+  uint32_t submit_flags = 0;
+  // SubmitForm /CharSet (PDF 2.0); empty when absent.
+  ByteString submit_charset;
+  // SubmitForm: whether /Fields was PRESENT — same presence-vs-empty
+  // distinction as |reset_has_fields|.
+  bool submit_has_fields = false;
   std::vector<EPDF_ACTION_NODE_ID> next;
 };
 
@@ -110,7 +154,12 @@ RetainPtr<const CPDF_Array> SnapshotDestination(const CPDF_Action& action,
   }
 
   auto snapshot = pdfium::MakeRetain<CPDF_Array>();
-  for (size_t i = 0; i < source->size(); ++i) {
+  // Copy only the elements FPDFDest can read; trailing junk in an oversized
+  // destination array neither grows the snapshot nor poisons the payload.
+  const size_t element_count = source->size() < kMaxDestinationElements
+                                   ? source->size()
+                                   : kMaxDestinationElements;
+  for (size_t i = 0; i < element_count; ++i) {
     RetainPtr<const CPDF_Object> value = source->GetDirectObjectAt(i);
     if (!value) {
       return nullptr;
@@ -143,11 +192,151 @@ struct ActionModelData {
 
 namespace {
 
+// Cumulative per-model build budgets. Overflow marks the model INCOMPLETE
+// and drops the node under construction, exactly like the depth and node
+// bounds — a dropped node never leaves a partial payload behind.
+struct BuildBudget {
+  size_t javascript_code_units = 0;
+  size_t target_entries = 0;
+  size_t payload_bytes = 0;
+};
+
+bool ChargePayloadBytes(size_t length,
+                        BuildBudget* budget,
+                        ActionModelData* model) {
+  if (length > kMaxActionPayloadBytes - budget->payload_bytes) {
+    model->warning_flags |= EPDF_ACTION_WARNING_INCOMPLETE;
+    return false;
+  }
+  budget->payload_bytes += length;
+  return true;
+}
+
+// Capture one Hide /T or ResetForm/SubmitForm /Fields entry list. Mirrors
+// CPDF_Action::GetAllFields()'s shape normalization (scalar-or-array,
+// strings and dictionary references) but never skips an unrepresentable
+// entry silently: executing a partial target list would hide or reset only
+// some of the intended objects, so such a list withholds itself via
+// |targets_valid| while the node's siblings and /Next chain stay usable.
+// Returns false only when an aggregate build budget was exhausted; the
+// model is then already marked INCOMPLETE and the caller drops the node.
+bool CaptureActionTargets(const CPDF_Dictionary* dict,
+                          BuildBudget* budget,
+                          ActionModelData* model,
+                          ActionNodeRecord* node) {
+  RetainPtr<const CPDF_Object> fields =
+      node->type == EPDF_ACTION_TYPE_HIDE ? dict->GetDirectObjectFor("T")
+                                          : dict->GetDirectObjectFor("Fields");
+  if (!fields) {
+    // No list: valid and empty. ResetForm presence rides |reset_has_fields|.
+    return true;
+  }
+
+  enum class Appended { kOk, kUnrepresentable, kOverBudget };
+  auto append = [&](const CPDF_Object* entry) {
+    if (!entry) {
+      return Appended::kUnrepresentable;
+    }
+    ActionTargetRecord target;
+    if (entry->IsString() || entry->IsName()) {
+      target.name = entry->GetUnicodeText().ToUTF8();
+    } else if (entry->IsDictionary() && entry->GetObjNum() != 0) {
+      // An indirect annotation/field dictionary reference. A direct inline
+      // dictionary has no durable identity and is unrepresentable.
+      target.object_number = entry->GetObjNum();
+    } else {
+      return Appended::kUnrepresentable;
+    }
+    if (budget->target_entries >= kMaxActionTargets ||
+        !ChargePayloadBytes(target.name.GetLength(), budget, model)) {
+      model->warning_flags |= EPDF_ACTION_WARNING_INCOMPLETE;
+      return Appended::kOverBudget;
+    }
+    ++budget->target_entries;
+    node->targets.push_back(std::move(target));
+    return Appended::kOk;
+  };
+
+  const auto withhold = [node]() {
+    node->targets.clear();
+    node->targets_valid = false;
+  };
+
+  if (const CPDF_Array* array = fields->AsArray()) {
+    for (size_t i = 0; i < array->size(); ++i) {
+      RetainPtr<const CPDF_Object> entry = array->GetDirectObjectAt(i);
+      switch (append(entry.Get())) {
+        case Appended::kOk:
+          break;
+        case Appended::kUnrepresentable:
+          withhold();
+          return true;
+        case Appended::kOverBudget:
+          return false;
+      }
+    }
+    return true;
+  }
+  switch (append(fields.Get())) {
+    case Appended::kOk:
+      return true;
+    case Appended::kUnrepresentable:
+      withhold();
+      return true;
+    case Appended::kOverBudget:
+      return false;
+  }
+  return true;
+}
+
+// Resolve SubmitForm's REQUIRED /F into a URL. The conforming target is a
+// URL file specification — << /FS /URL /F (uri) >> (ISO 32000-2 7.11.5),
+// with /UF preferred over /F when both exist (7.11.2). A bare string or
+// name /F is accepted as a producer-compat extension and read verbatim.
+// Anything else (missing /F, a non-URL file specification, an empty URL)
+// leaves |submit_url_valid| false: the required payload stays withheld and
+// the reader degrades the node — never a half payload. Returns false only
+// when the aggregate payload budget was exhausted (the model is then
+// already marked INCOMPLETE and the caller drops the node).
+bool CaptureSubmitFormUrl(const CPDF_Dictionary* dict,
+                          BuildBudget* budget,
+                          ActionModelData* model,
+                          ActionNodeRecord* node) {
+  RetainPtr<const CPDF_Object> file = dict->GetDirectObjectFor("F");
+  ByteString url;
+  if (file && (file->IsString() || file->IsName())) {
+    url = file->GetUnicodeText().ToUTF8();
+  } else if (file && file->IsDictionary()) {
+    const CPDF_Dictionary* spec = file->AsDictionary();
+    if (spec->GetNameFor("FS") != "URL") {
+      return true;
+    }
+    RetainPtr<const CPDF_Object> uf = spec->GetDirectObjectFor("UF");
+    if (uf && (uf->IsString() || uf->IsName())) {
+      url = uf->GetUnicodeText().ToUTF8();
+    } else {
+      RetainPtr<const CPDF_Object> f = spec->GetDirectObjectFor("F");
+      if (f && (f->IsString() || f->IsName())) {
+        url = f->GetUnicodeText().ToUTF8();
+      }
+    }
+  }
+  if (url.IsEmpty()) {
+    return true;
+  }
+  if (!ChargePayloadBytes(url.GetLength(), budget, model)) {
+    return false;
+  }
+  node->submit_url = std::move(url);
+  node->submit_url_valid = true;
+  return true;
+}
+
 std::optional<EPDF_ACTION_NODE_ID> AppendAction(
     const CPDF_Action& action,
     CPDF_Document* document,
     size_t depth,
-    size_t* javascript_code_units,
+    BuildBudget* budget,
     std::set<const CPDF_Dictionary*>* active_path,
     ActionModelData* model) {
   const CPDF_Dictionary* dict = action.GetDict();
@@ -168,11 +357,11 @@ std::optional<EPDF_ACTION_NODE_ID> AppendAction(
     node.javascript = action.MaybeGetJavaScript();
     if (node.javascript.has_value()) {
       const size_t length = node.javascript->GetLength();
-      if (length > kMaxJavaScriptCodeUnits - *javascript_code_units) {
+      if (length > kMaxJavaScriptCodeUnits - budget->javascript_code_units) {
         model->warning_flags |= EPDF_ACTION_WARNING_INCOMPLETE;
         return std::nullopt;
       }
-      *javascript_code_units += length;
+      budget->javascript_code_units += length;
     }
   }
   if (node.type == EPDF_ACTION_TYPE_GOTO ||
@@ -184,19 +373,57 @@ std::optional<EPDF_ACTION_NODE_ID> AppendAction(
     if (!node.destination && raw_destination &&
         (raw_destination->IsName() || raw_destination->IsString())) {
       node.named_destination = raw_destination->GetString();
+      if (!ChargePayloadBytes(node.named_destination.GetLength(), budget,
+                              model)) {
+        return std::nullopt;
+      }
     }
   }
   if (node.type == EPDF_ACTION_TYPE_URI) {
     node.uri =
         document ? action.GetURI(document) : dict->GetByteStringFor("URI");
+    node.is_map = dict->GetBooleanFor("IsMap", false);
+    if (!ChargePayloadBytes(node.uri.GetLength(), budget, model)) {
+      return std::nullopt;
+    }
   }
   if (node.type == EPDF_ACTION_TYPE_GOTO_REMOTE ||
       node.type == EPDF_ACTION_TYPE_GOTO_EMBEDDED ||
       node.type == EPDF_ACTION_TYPE_LAUNCH) {
     node.file_path = action.GetFilePath().ToUTF8();
+    if (!ChargePayloadBytes(node.file_path.GetLength(), budget, model)) {
+      return std::nullopt;
+    }
   }
   if (node.type == EPDF_ACTION_TYPE_NAMED) {
     node.name = dict->GetNameFor("N");
+    if (!ChargePayloadBytes(node.name.GetLength(), budget, model)) {
+      return std::nullopt;
+    }
+  }
+  if (node.type == EPDF_ACTION_TYPE_HIDE ||
+      node.type == EPDF_ACTION_TYPE_RESET_FORM) {
+    if (node.type == EPDF_ACTION_TYPE_HIDE) {
+      node.hide = action.GetHideStatus();
+    } else {
+      node.reset_has_fields = action.HasFields();
+      node.exclude = (action.GetFlags() & 1) != 0;
+    }
+    if (!CaptureActionTargets(dict, budget, model, &node)) {
+      return std::nullopt;
+    }
+  }
+  if (node.type == EPDF_ACTION_TYPE_SUBMIT_FORM) {
+    node.submit_has_fields = action.HasFields();
+    node.submit_flags = action.GetFlags();
+    node.submit_charset = dict->GetUnicodeTextFor("CharSet").ToUTF8();
+    if (!ChargePayloadBytes(node.submit_charset.GetLength(), budget, model)) {
+      return std::nullopt;
+    }
+    if (!CaptureSubmitFormUrl(dict, budget, model, &node) ||
+        !CaptureActionTargets(dict, budget, model, &node)) {
+      return std::nullopt;
+    }
   }
 
   const EPDF_ACTION_NODE_ID node_id =
@@ -222,8 +449,8 @@ std::optional<EPDF_ACTION_NODE_ID> AppendAction(
       model->warning_flags |= EPDF_ACTION_WARNING_CYCLE_DROPPED;
       continue;
     }
-    std::optional<EPDF_ACTION_NODE_ID> child_id = AppendAction(
-        child, document, depth + 1, javascript_code_units, active_path, model);
+    std::optional<EPDF_ACTION_NODE_ID> child_id =
+        AppendAction(child, document, depth + 1, budget, active_path, model);
     if (child_id.has_value()) {
       model->nodes[node_id].next.push_back(child_id.value());
     }
@@ -243,10 +470,9 @@ ActionModelDataPtr BuildActionModel(const CPDF_Action& action,
     return nullptr;
   }
   auto model = std::make_shared<ActionModelData>();
-  size_t javascript_code_units = 0;
+  BuildBudget budget;
   std::set<const CPDF_Dictionary*> active_path;
-  AppendAction(action, document, 0, &javascript_code_units, &active_path,
-               model.get());
+  AppendAction(action, document, 0, &budget, &active_path, model.get());
   return model;
 }
 
@@ -446,6 +672,159 @@ EPDFAction_GetNodeName(EPDF_ACTION_MODEL model,
       record->name, UNSAFE_BUFFERS(SpanFromFPDFApiArgs(buffer, buflen)));
 }
 
+namespace {
+
+const epdf::ActionNodeRecord* GetTargetListNode(EPDF_ACTION_MODEL model,
+                                                EPDF_ACTION_NODE_ID node) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || (record->type != EPDF_ACTION_TYPE_HIDE &&
+                  record->type != EPDF_ACTION_TYPE_RESET_FORM &&
+                  record->type != EPDF_ACTION_TYPE_SUBMIT_FORM)) {
+    return nullptr;
+  }
+  return record;
+}
+
+const epdf::ActionTargetRecord* GetActionTarget(EPDF_ACTION_MODEL model,
+                                                EPDF_ACTION_NODE_ID node,
+                                                int index) {
+  const epdf::ActionNodeRecord* record = GetTargetListNode(model, node);
+  if (!record || !record->targets_valid || index < 0 ||
+      static_cast<size_t>(index) >= record->targets.size()) {
+    return nullptr;
+  }
+  return &record->targets[static_cast<size_t>(index)];
+}
+
+}  // namespace
+
+FPDF_EXPORT int FPDF_CALLCONV
+EPDFAction_GetNodeTargetCount(EPDF_ACTION_MODEL model,
+                              EPDF_ACTION_NODE_ID node) {
+  const epdf::ActionNodeRecord* record = GetTargetListNode(model, node);
+  if (!record) {
+    return 0;
+  }
+  if (!record->targets_valid) {
+    return -1;
+  }
+  return pdfium::checked_cast<int>(record->targets.size());
+}
+
+FPDF_EXPORT unsigned long FPDF_CALLCONV
+EPDFAction_GetNodeTargetName(EPDF_ACTION_MODEL model,
+                             EPDF_ACTION_NODE_ID node,
+                             int index,
+                             void* buffer,
+                             unsigned long buflen) {
+  const epdf::ActionTargetRecord* target = GetActionTarget(model, node, index);
+  if (!target || target->object_number != 0) {
+    return 0;
+  }
+  // SAFETY: required from caller.
+  return NulTerminateMaybeCopyAndReturnLength(
+      target->name, UNSAFE_BUFFERS(SpanFromFPDFApiArgs(buffer, buflen)));
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeTargetObjectNumber(EPDF_ACTION_MODEL model,
+                                     EPDF_ACTION_NODE_ID node,
+                                     int index,
+                                     unsigned int* object_number) {
+  const epdf::ActionTargetRecord* target = GetActionTarget(model, node, index);
+  if (!target || target->object_number == 0 || !object_number) {
+    return false;
+  }
+  *object_number = target->object_number;
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeHideFlag(EPDF_ACTION_MODEL model,
+                           EPDF_ACTION_NODE_ID node,
+                           FPDF_BOOL* hide) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || record->type != EPDF_ACTION_TYPE_HIDE || !hide) {
+    return false;
+  }
+  *hide = record->hide;
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeResetForm(EPDF_ACTION_MODEL model,
+                            EPDF_ACTION_NODE_ID node,
+                            FPDF_BOOL* has_fields,
+                            FPDF_BOOL* exclude) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || record->type != EPDF_ACTION_TYPE_RESET_FORM || !has_fields ||
+      !exclude) {
+    return false;
+  }
+  *has_fields = record->reset_has_fields;
+  *exclude = record->exclude;
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeSubmitForm(EPDF_ACTION_MODEL model,
+                             EPDF_ACTION_NODE_ID node,
+                             FPDF_BOOL* has_fields,
+                             unsigned int* flags) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || record->type != EPDF_ACTION_TYPE_SUBMIT_FORM ||
+      !record->submit_url_valid || !has_fields || !flags) {
+    return false;
+  }
+  *has_fields = record->submit_has_fields;
+  *flags = record->submit_flags;
+  return true;
+}
+
+FPDF_EXPORT unsigned long FPDF_CALLCONV
+EPDFAction_GetNodeSubmitFormURL(EPDF_ACTION_MODEL model,
+                                EPDF_ACTION_NODE_ID node,
+                                void* buffer,
+                                unsigned long buflen) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || record->type != EPDF_ACTION_TYPE_SUBMIT_FORM ||
+      !record->submit_url_valid) {
+    return 0;
+  }
+  // SAFETY: required from caller.
+  return NulTerminateMaybeCopyAndReturnLength(
+      record->submit_url,
+      UNSAFE_BUFFERS(SpanFromFPDFApiArgs(buffer, buflen)));
+}
+
+FPDF_EXPORT unsigned long FPDF_CALLCONV
+EPDFAction_GetNodeSubmitFormCharSet(EPDF_ACTION_MODEL model,
+                                    EPDF_ACTION_NODE_ID node,
+                                    void* buffer,
+                                    unsigned long buflen) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || record->type != EPDF_ACTION_TYPE_SUBMIT_FORM ||
+      record->submit_charset.IsEmpty()) {
+    return 0;
+  }
+  // SAFETY: required from caller.
+  return NulTerminateMaybeCopyAndReturnLength(
+      record->submit_charset,
+      UNSAFE_BUFFERS(SpanFromFPDFApiArgs(buffer, buflen)));
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeURIIsMap(EPDF_ACTION_MODEL model,
+                           EPDF_ACTION_NODE_ID node,
+                           FPDF_BOOL* is_map) {
+  const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
+  if (!record || record->type != EPDF_ACTION_TYPE_URI || !is_map) {
+    return false;
+  }
+  *is_map = record->is_map;
+  return true;
+}
+
 FPDF_EXPORT int FPDF_CALLCONV
 EPDFAction_GetNextCount(EPDF_ACTION_MODEL model, EPDF_ACTION_NODE_ID node) {
   const epdf::ActionNodeRecord* record = epdf::GetNode(model, node);
@@ -485,6 +864,32 @@ EPDFDoc_GetOpenActionModel(FPDF_DOCUMENT document) {
   return root ? epdf::MakeModelFromDictionary(root->GetDictFor("OpenAction"),
                                               doc)
               : nullptr;
+}
+
+FPDF_EXPORT FPDF_DEST FPDF_CALLCONV
+EPDFDoc_GetOpenActionDest(FPDF_DOCUMENT document) {
+  ScopedFPDFDocumentView document_view(document);
+  CPDF_Document* doc = document_view.Get();
+  const CPDF_Dictionary* root = doc ? doc->GetRoot() : nullptr;
+  if (!root) {
+    return nullptr;
+  }
+  RetainPtr<const CPDF_Object> open_action =
+      root->GetDirectObjectFor("OpenAction");
+  if (!open_action) {
+    return nullptr;
+  }
+  if (const CPDF_Array* array = open_action->AsArray()) {
+    // The handle points into the live catalog, like FPDFLink_GetDest.
+    return FPDFDestFromCPDFArray(array);
+  }
+  if (open_action->IsString() || open_action->IsName()) {
+    RetainPtr<const CPDF_Array> named =
+        CPDF_NameTree::LookupNamedDest(doc, open_action->GetString());
+    return FPDFDestFromCPDFArray(named.Get());
+  }
+  // The action form reads through EPDFDoc_GetOpenActionModel.
+  return nullptr;
 }
 
 FPDF_EXPORT EPDF_ACTION_MODEL FPDF_CALLCONV

--- a/fpdfsdk/epdf_action_embeddertest.cpp
+++ b/fpdfsdk/epdf_action_embeddertest.cpp
@@ -9,6 +9,7 @@
 
 #include "core/fpdfapi/page/cpdf_page.h"
 #include "core/fpdfapi/parser/cpdf_array.h"
+#include "core/fpdfapi/parser/cpdf_boolean.h"
 #include "core/fpdfapi/parser/cpdf_dictionary.h"
 #include "core/fpdfapi/parser/cpdf_document.h"
 #include "core/fpdfapi/parser/cpdf_name.h"
@@ -84,6 +85,20 @@ RetainPtr<CPDF_Dictionary> MakeJavaScriptAction(const wchar_t* script) {
   action->SetNewFor<CPDF_Name>("S", "JavaScript");
   action->SetNewFor<CPDF_String>("JS", script);
   return action;
+}
+
+std::string GetTargetName(EPDF_ACTION_MODEL model,
+                          EPDF_ACTION_NODE_ID node,
+                          int index) {
+  const unsigned long length =
+      EPDFAction_GetNodeTargetName(model, node, index, nullptr, 0);
+  if (length == 0) {
+    return std::string();
+  }
+  std::vector<char> buffer(length);
+  EXPECT_EQ(length, EPDFAction_GetNodeTargetName(model, node, index,
+                                                 buffer.data(), length));
+  return std::string(buffer.data());
 }
 
 }  // namespace
@@ -555,4 +570,329 @@ TEST_F(EPDFActionEmbedderTest, NodeFilePathAndNamePayloadsFromSyntheticDicts) {
                                         nullptr, 0));
   EXPECT_EQ(0ul, EPDFAction_GetNodeFilePath(named_model.get(), named_root,
                                             nullptr, 0));
+}
+
+TEST_F(EPDFActionEmbedderTest, HideTargetPayloadsMixedForms) {
+  ScopedFPDFDocument document(FPDF_CreateNewDocument());
+  ASSERT_TRUE(document);
+  CPDF_Document* doc = CPDFDocumentFromFPDFDocument(document.get());
+  ASSERT_TRUE(doc);
+
+  RetainPtr<CPDF_Dictionary> widget = doc->NewIndirect<CPDF_Dictionary>();
+  RetainPtr<CPDF_Dictionary> hide = doc->NewIndirect<CPDF_Dictionary>();
+  hide->SetNewFor<CPDF_Name>("S", "Hide");
+  hide->SetNewFor<CPDF_Boolean>("H", false);
+  RetainPtr<CPDF_Array> targets = hide->SetNewFor<CPDF_Array>("T");
+  targets->AppendNew<CPDF_String>(L"note1");
+  targets->AppendNew<CPDF_Reference>(doc, widget->GetObjNum());
+
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(hide.Get())));
+  ASSERT_TRUE(model);
+  const EPDF_ACTION_NODE_ID root = EPDFAction_GetRootNode(model.get());
+  ASSERT_EQ(EPDF_ACTION_TYPE_HIDE, EPDFAction_GetNodeType(model.get(), root));
+
+  ASSERT_EQ(2, EPDFAction_GetNodeTargetCount(model.get(), root));
+  EXPECT_EQ("note1", GetTargetName(model.get(), root, 0));
+  unsigned int object_number = 0;
+  EXPECT_FALSE(EPDFAction_GetNodeTargetObjectNumber(model.get(), root, 0,
+                                                    &object_number));
+  ASSERT_TRUE(EPDFAction_GetNodeTargetObjectNumber(model.get(), root, 1,
+                                                   &object_number));
+  EXPECT_EQ(widget->GetObjNum(), object_number);
+  EXPECT_EQ(0ul,
+            EPDFAction_GetNodeTargetName(model.get(), root, 1, nullptr, 0));
+  EXPECT_EQ(0ul,
+            EPDFAction_GetNodeTargetName(model.get(), root, 2, nullptr, 0));
+
+  FPDF_BOOL hide_flag = true;
+  ASSERT_TRUE(EPDFAction_GetNodeHideFlag(model.get(), root, &hide_flag));
+  EXPECT_FALSE(hide_flag);
+
+  // Wrong-type gates answer empty/false rather than lying.
+  FPDF_BOOL has_fields = false;
+  FPDF_BOOL exclude = false;
+  EXPECT_FALSE(
+      EPDFAction_GetNodeResetForm(model.get(), root, &has_fields, &exclude));
+  FPDF_BOOL is_map = false;
+  EXPECT_FALSE(EPDFAction_GetNodeURIIsMap(model.get(), root, &is_map));
+}
+
+TEST_F(EPDFActionEmbedderTest, HideScalarTargetAndDefaultFlag) {
+  auto hide = pdfium::MakeRetain<CPDF_Dictionary>();
+  hide->SetNewFor<CPDF_Name>("S", "Hide");
+  hide->SetNewFor<CPDF_String>("T", L"fieldA");
+
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(hide.Get())));
+  ASSERT_TRUE(model);
+  const EPDF_ACTION_NODE_ID root = EPDFAction_GetRootNode(model.get());
+  ASSERT_EQ(1, EPDFAction_GetNodeTargetCount(model.get(), root));
+  EXPECT_EQ("fieldA", GetTargetName(model.get(), root, 0));
+
+  FPDF_BOOL hide_flag = false;
+  ASSERT_TRUE(EPDFAction_GetNodeHideFlag(model.get(), root, &hide_flag));
+  EXPECT_TRUE(hide_flag);
+
+  // A JavaScript node carries no target list at all.
+  RetainPtr<CPDF_Dictionary> script = MakeJavaScriptAction(L"noop();");
+  ScopedEPDFActionModel script_model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(script.Get())));
+  ASSERT_TRUE(script_model);
+  EXPECT_EQ(0, EPDFAction_GetNodeTargetCount(script_model.get(), 0));
+  EXPECT_FALSE(EPDFAction_GetNodeHideFlag(script_model.get(), 0, &hide_flag));
+}
+
+TEST_F(EPDFActionEmbedderTest, PartialHideTargetListIsWithheld) {
+  auto hide = pdfium::MakeRetain<CPDF_Dictionary>();
+  hide->SetNewFor<CPDF_Name>("S", "Hide");
+  RetainPtr<CPDF_Array> targets = hide->SetNewFor<CPDF_Array>("T");
+  targets->AppendNew<CPDF_String>(L"kept");
+  // A direct inline dictionary has no durable identity. Executing the
+  // remaining targets would hide only part of what the author intended, so
+  // the whole list is withheld while the node and its chain stay readable.
+  targets->AppendNew<CPDF_Dictionary>();
+
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(hide.Get())));
+  ASSERT_TRUE(model);
+  const EPDF_ACTION_NODE_ID root = EPDFAction_GetRootNode(model.get());
+  ASSERT_EQ(EPDF_ACTION_TYPE_HIDE, EPDFAction_GetNodeType(model.get(), root));
+  EXPECT_EQ(-1, EPDFAction_GetNodeTargetCount(model.get(), root));
+  EXPECT_EQ(0ul,
+            EPDFAction_GetNodeTargetName(model.get(), root, 0, nullptr, 0));
+  unsigned int object_number = 0;
+  EXPECT_FALSE(EPDFAction_GetNodeTargetObjectNumber(model.get(), root, 0,
+                                                    &object_number));
+  // Semantic withholding is per-node, not a resource fault: the model as a
+  // whole remains complete.
+  EXPECT_FALSE(EPDFAction_GetWarningFlags(model.get()) &
+               EPDF_ACTION_WARNING_INCOMPLETE);
+  EXPECT_TRUE(EPDFAction_IsComplete(model.get()));
+}
+
+TEST_F(EPDFActionEmbedderTest, ResetFormThreeStates) {
+  ScopedFPDFDocument document(FPDF_CreateNewDocument());
+  ASSERT_TRUE(document);
+  CPDF_Document* doc = CPDFDocumentFromFPDFDocument(document.get());
+  ASSERT_TRUE(doc);
+  RetainPtr<CPDF_Dictionary> field = doc->NewIndirect<CPDF_Dictionary>();
+
+  // /Fields ABSENT: reset everything; flags are meaningless.
+  auto reset_all = pdfium::MakeRetain<CPDF_Dictionary>();
+  reset_all->SetNewFor<CPDF_Name>("S", "ResetForm");
+  reset_all->SetNewFor<CPDF_Number>("Flags", 1);
+  ScopedEPDFActionModel all_model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(reset_all.Get())));
+  ASSERT_TRUE(all_model);
+  FPDF_BOOL has_fields = true;
+  FPDF_BOOL exclude = false;
+  ASSERT_TRUE(
+      EPDFAction_GetNodeResetForm(all_model.get(), 0, &has_fields, &exclude));
+  EXPECT_FALSE(has_fields);
+  EXPECT_TRUE(exclude);
+  EXPECT_EQ(0, EPDFAction_GetNodeTargetCount(all_model.get(), 0));
+
+  // /Fields present but EMPTY: a different state from absent.
+  auto reset_none = pdfium::MakeRetain<CPDF_Dictionary>();
+  reset_none->SetNewFor<CPDF_Name>("S", "ResetForm");
+  reset_none->SetNewFor<CPDF_Array>("Fields");
+  ScopedEPDFActionModel none_model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(reset_none.Get())));
+  ASSERT_TRUE(none_model);
+  ASSERT_TRUE(
+      EPDFAction_GetNodeResetForm(none_model.get(), 0, &has_fields, &exclude));
+  EXPECT_TRUE(has_fields);
+  EXPECT_FALSE(exclude);
+  EXPECT_EQ(0, EPDFAction_GetNodeTargetCount(none_model.get(), 0));
+
+  // Non-empty exclusion list mixing a name and a field reference.
+  auto reset_some = pdfium::MakeRetain<CPDF_Dictionary>();
+  reset_some->SetNewFor<CPDF_Name>("S", "ResetForm");
+  reset_some->SetNewFor<CPDF_Number>("Flags", 1);
+  RetainPtr<CPDF_Array> fields = reset_some->SetNewFor<CPDF_Array>("Fields");
+  fields->AppendNew<CPDF_String>(L"calc1");
+  fields->AppendNew<CPDF_Reference>(doc, field->GetObjNum());
+  ScopedEPDFActionModel some_model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(reset_some.Get())));
+  ASSERT_TRUE(some_model);
+  ASSERT_TRUE(
+      EPDFAction_GetNodeResetForm(some_model.get(), 0, &has_fields, &exclude));
+  EXPECT_TRUE(has_fields);
+  EXPECT_TRUE(exclude);
+  ASSERT_EQ(2, EPDFAction_GetNodeTargetCount(some_model.get(), 0));
+  EXPECT_EQ("calc1", GetTargetName(some_model.get(), 0, 0));
+  unsigned int object_number = 0;
+  ASSERT_TRUE(EPDFAction_GetNodeTargetObjectNumber(some_model.get(), 0, 1,
+                                                   &object_number));
+  EXPECT_EQ(field->GetObjNum(), object_number);
+}
+
+TEST_F(EPDFActionEmbedderTest, UriIsMapPayload) {
+  auto uri = pdfium::MakeRetain<CPDF_Dictionary>();
+  uri->SetNewFor<CPDF_Name>("S", "URI");
+  uri->SetNewFor<CPDF_String>("URI", "https://example.test/map");
+  uri->SetNewFor<CPDF_Boolean>("IsMap", true);
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(uri.Get())));
+  ASSERT_TRUE(model);
+  FPDF_BOOL is_map = false;
+  ASSERT_TRUE(EPDFAction_GetNodeURIIsMap(model.get(), 0, &is_map));
+  EXPECT_TRUE(is_map);
+
+  auto plain = pdfium::MakeRetain<CPDF_Dictionary>();
+  plain->SetNewFor<CPDF_Name>("S", "URI");
+  plain->SetNewFor<CPDF_String>("URI", "https://example.test/");
+  ScopedEPDFActionModel plain_model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(plain.Get())));
+  ASSERT_TRUE(plain_model);
+  is_map = true;
+  ASSERT_TRUE(EPDFAction_GetNodeURIIsMap(plain_model.get(), 0, &is_map));
+  EXPECT_FALSE(is_map);
+
+  RetainPtr<CPDF_Dictionary> named = pdfium::MakeRetain<CPDF_Dictionary>();
+  named->SetNewFor<CPDF_Name>("S", "Named");
+  named->SetNewFor<CPDF_Name>("N", "NextPage");
+  ScopedEPDFActionModel named_model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(named.Get())));
+  ASSERT_TRUE(named_model);
+  EXPECT_FALSE(EPDFAction_GetNodeURIIsMap(named_model.get(), 0, &is_map));
+}
+
+TEST_F(EPDFActionEmbedderTest, TargetBudgetOverflowDropsNodeAndMarksIncomplete) {
+  auto hide = pdfium::MakeRetain<CPDF_Dictionary>();
+  hide->SetNewFor<CPDF_Name>("S", "Hide");
+  RetainPtr<CPDF_Array> targets = hide->SetNewFor<CPDF_Array>("T");
+  for (int i = 0; i < 2049; ++i) {
+    targets->AppendNew<CPDF_String>("t");
+  }
+
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(hide.Get())));
+  ASSERT_TRUE(model);
+  // The node under construction is dropped whole — never a partial list.
+  EXPECT_EQ(0, EPDFAction_GetNodeCount(model.get()));
+  EXPECT_EQ(EPDF_ACTION_NODE_INVALID, EPDFAction_GetRootNode(model.get()));
+  EXPECT_TRUE(EPDFAction_GetWarningFlags(model.get()) &
+              EPDF_ACTION_WARNING_INCOMPLETE);
+  EXPECT_FALSE(EPDFAction_IsComplete(model.get()));
+}
+
+TEST_F(EPDFActionEmbedderTest, PayloadByteBudgetOverflowDropsNode) {
+  const std::string big((1 << 20) + 1, 'a');
+  auto uri = pdfium::MakeRetain<CPDF_Dictionary>();
+  uri->SetNewFor<CPDF_Name>("S", "URI");
+  uri->SetNewFor<CPDF_String>("URI", ByteString(big.c_str()));
+
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(uri.Get())));
+  ASSERT_TRUE(model);
+  EXPECT_EQ(0, EPDFAction_GetNodeCount(model.get()));
+  EXPECT_TRUE(EPDFAction_GetWarningFlags(model.get()) &
+              EPDF_ACTION_WARNING_INCOMPLETE);
+  EXPECT_FALSE(EPDFAction_IsComplete(model.get()));
+}
+
+TEST_F(EPDFActionEmbedderTest, OpenActionDestinationForms) {
+  // Absent /OpenAction: both readers answer null.
+  ScopedFPDFDocument empty(FPDF_CreateNewDocument());
+  ASSERT_TRUE(empty);
+  EXPECT_FALSE(EPDFDoc_GetOpenActionDest(empty.get()));
+  EXPECT_FALSE(EPDFDoc_GetOpenActionModel(empty.get()));
+  EXPECT_FALSE(EPDFDoc_GetOpenActionDest(nullptr));
+
+  // Destination form: the dest reads, the action model stays null.
+  ScopedFPDFDocument document(FPDF_CreateNewDocument());
+  ASSERT_TRUE(document);
+  ScopedFPDFPage page(FPDFPage_New(document.get(), 0, 612, 792));
+  ASSERT_TRUE(page);
+  const uint32_t page_objnum = EPDFPage_GetObjectNumber(page.get());
+  ASSERT_GT(page_objnum, 0u);
+  CPDF_Document* doc = CPDFDocumentFromFPDFDocument(document.get());
+  ASSERT_TRUE(doc);
+  RetainPtr<CPDF_Array> open_action =
+      doc->GetMutableRoot()->SetNewFor<CPDF_Array>("OpenAction");
+  open_action->AppendNew<CPDF_Reference>(doc, page_objnum);
+  open_action->AppendNew<CPDF_Name>("XYZ");
+  open_action->AppendNew<CPDF_Number>(10);
+  open_action->AppendNew<CPDF_Number>(700);
+  open_action->AppendNew<CPDF_Number>(1.5f);
+
+  FPDF_DEST dest = EPDFDoc_GetOpenActionDest(document.get());
+  ASSERT_TRUE(dest);
+  EXPECT_FALSE(EPDFDoc_GetOpenActionModel(document.get()));
+  EXPECT_EQ(page_objnum,
+            EPDFDest_GetPageObjectNumber(document.get(), dest));
+  FPDF_BOOL has_x = false;
+  FPDF_BOOL has_y = false;
+  FPDF_BOOL has_zoom = false;
+  FS_FLOAT x = 0;
+  FS_FLOAT y = 0;
+  FS_FLOAT zoom = 0;
+  ASSERT_TRUE(
+      FPDFDest_GetLocationInPage(dest, &has_x, &has_y, &has_zoom, &x, &y,
+                                 &zoom));
+  EXPECT_TRUE(has_x);
+  EXPECT_TRUE(has_y);
+  EXPECT_TRUE(has_zoom);
+  EXPECT_FLOAT_EQ(10.0f, x);
+  EXPECT_FLOAT_EQ(700.0f, y);
+  EXPECT_FLOAT_EQ(1.5f, zoom);
+
+  // A named value without a name tree resolves to nothing rather than lying.
+  doc->GetMutableRoot()->SetNewFor<CPDF_Name>("OpenAction", "missing");
+  EXPECT_FALSE(EPDFDoc_GetOpenActionDest(document.get()));
+
+  // Action form: the model reads, the dest stays null.
+  doc->GetMutableRoot()->SetFor("OpenAction", MakeJavaScriptAction(L"open();"));
+  ScopedEPDFActionModel action_model(
+      EPDFDoc_GetOpenActionModel(document.get()));
+  EXPECT_TRUE(action_model);
+  EXPECT_FALSE(EPDFDoc_GetOpenActionDest(document.get()));
+}
+
+TEST_F(EPDFActionEmbedderTest, DestinationArrayJunkBeyondViewIsIgnored) {
+  ScopedFPDFDocument document(FPDF_CreateNewDocument());
+  ASSERT_TRUE(document);
+  ScopedFPDFPage page(FPDFPage_New(document.get(), 0, 612, 792));
+  ASSERT_TRUE(page);
+  const uint32_t page_objnum = EPDFPage_GetObjectNumber(page.get());
+  ASSERT_GT(page_objnum, 0u);
+  CPDF_Document* doc = CPDFDocumentFromFPDFDocument(document.get());
+  ASSERT_TRUE(doc);
+
+  RetainPtr<CPDF_Dictionary> go_to = doc->NewIndirect<CPDF_Dictionary>();
+  go_to->SetNewFor<CPDF_Name>("S", "GoTo");
+  RetainPtr<CPDF_Array> destination = go_to->SetNewFor<CPDF_Array>("D");
+  destination->AppendNew<CPDF_Reference>(doc, page_objnum);
+  destination->AppendNew<CPDF_Name>("XYZ");
+  destination->AppendNew<CPDF_Number>(1);
+  destination->AppendNew<CPDF_Number>(2);
+  destination->AppendNew<CPDF_Number>(3);
+  for (int i = 0; i < 5; ++i) {
+    destination->AppendNew<CPDF_Number>(99);
+  }
+
+  ScopedEPDFActionModel model(
+      EPDFAction_LoadModel(FPDFActionFromCPDFDictionary(go_to.Get())));
+  ASSERT_TRUE(model);
+  const EPDF_ACTION_NODE_ID root = EPDFAction_GetRootNode(model.get());
+  ASSERT_EQ(EPDF_ACTION_TYPE_GOTO, EPDFAction_GetNodeType(model.get(), root));
+
+  FPDF_DEST dest = EPDFAction_GetNodeDest(document.get(), model.get(), root);
+  ASSERT_TRUE(dest);
+  EXPECT_EQ(page_objnum,
+            EPDFDest_GetPageObjectNumber(document.get(), dest));
+  FPDF_BOOL has_x = false;
+  FPDF_BOOL has_y = false;
+  FPDF_BOOL has_zoom = false;
+  FS_FLOAT x = 0;
+  FS_FLOAT y = 0;
+  FS_FLOAT zoom = 0;
+  ASSERT_TRUE(
+      FPDFDest_GetLocationInPage(dest, &has_x, &has_y, &has_zoom, &x, &y,
+                                 &zoom));
+  EXPECT_FLOAT_EQ(1.0f, x);
+  EXPECT_FLOAT_EQ(2.0f, y);
+  EXPECT_FLOAT_EQ(3.0f, zoom);
 }

--- a/public/epdf_action.h
+++ b/public/epdf_action.h
@@ -17,8 +17,9 @@ extern "C" {
 //
 // Detached PDF action model. A model contains one root action and its
 // normalized /Next descendants. Type, subtype, script, chain, destination,
-// URI, file path, and named-action payloads are copied at build time and stay
-// valid after the document is closed or mutated. The getters that take an
+// URI (with /IsMap), file path, named-action, Hide /T + /H, and ResetForm
+// /Fields + /Flags payloads are copied at build time and stay valid after
+// the document is closed or mutated. The getters that take an
 // FPDF_DOCUMENT still require the originating document to be open: it
 // validates destination page identity and is used to resolve a named
 // destination when EPDFAction_LoadModel() had no document owner available.
@@ -139,6 +140,95 @@ EPDFAction_GetNodeName(EPDF_ACTION_MODEL model,
                        void* buffer,
                        unsigned long buflen);
 
+// Number of Hide /T, ResetForm /Fields, or SubmitForm /Fields entries
+// captured for |node|. Returns 0 for other node types, and -1 when an entry
+// could not be represented: a partial target list must never execute, so
+// consumers treat -1 as an unreadable payload and degrade the node.
+FPDF_EXPORT int FPDF_CALLCONV
+EPDFAction_GetNodeTargetCount(EPDF_ACTION_MODEL model,
+                              EPDF_ACTION_NODE_ID node);
+
+// Copy target |index|'s field name as UTF-8, including the trailing NUL.
+// Returns the required byte length, or 0 when the entry is an object
+// reference rather than a name, the index is out of range, or the node
+// carries no target list. |buffer| may be NULL to query the length.
+FPDF_EXPORT unsigned long FPDF_CALLCONV
+EPDFAction_GetNodeTargetName(EPDF_ACTION_MODEL model,
+                             EPDF_ACTION_NODE_ID node,
+                             int index,
+                             void* buffer,
+                             unsigned long buflen);
+
+// Get target |index|'s indirect object number (an annotation or field
+// dictionary reference). Returns false when the entry is a name rather than
+// an object reference, the index is out of range, or the node carries no
+// target list. |object_number| is only written on success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeTargetObjectNumber(EPDF_ACTION_MODEL model,
+                                     EPDF_ACTION_NODE_ID node,
+                                     int index,
+                                     unsigned int* object_number);
+
+// Hide /H for a hide-type |node|: true hides (the spec default), false
+// shows. Returns false for other node types; |hide| is only written on
+// success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeHideFlag(EPDF_ACTION_MODEL model,
+                           EPDF_ACTION_NODE_ID node,
+                           FPDF_BOOL* hide);
+
+// ResetForm state for a reset-form-type |node|: |has_fields| reports whether
+// /Fields was PRESENT (absent means "reset every field" and |exclude| is
+// meaningless); |exclude| is /Flags bit 0 (set = /Fields lists EXCLUDED
+// fields). Returns false for other node types; out-params are only written
+// on success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeResetForm(EPDF_ACTION_MODEL model,
+                            EPDF_ACTION_NODE_ID node,
+                            FPDF_BOOL* has_fields,
+                            FPDF_BOOL* exclude);
+
+// SubmitForm state for a submit-form-type |node|. Returns true only when
+// the REQUIRED /F resolved to a URL — a << /FS /URL >> file specification
+// (ISO 32000-2 7.11.5, /UF preferred over /F per 7.11.2), or a bare
+// string/name /F accepted as a producer-compat extension. Returns false
+// otherwise, including for a submit-form node whose payload was withheld —
+// consumers degrade such a node instead of executing a half payload.
+// |has_fields| reports whether /Fields was PRESENT (same presence-vs-empty
+// distinction as ResetForm); |flags| is the raw /Flags word (ISO 32000-2
+// Table 240, bits numbered from 1). Out-params are only written on success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeSubmitForm(EPDF_ACTION_MODEL model,
+                             EPDF_ACTION_NODE_ID node,
+                             FPDF_BOOL* has_fields,
+                             unsigned int* flags);
+
+// Copy the resolved submission URL of a submit-form-type |node| as UTF-8,
+// including the trailing NUL. Returns the required byte length, or 0 when
+// the node is not a submit-form action or its payload was withheld.
+// |buffer| may be NULL to query the length.
+FPDF_EXPORT unsigned long FPDF_CALLCONV
+EPDFAction_GetNodeSubmitFormURL(EPDF_ACTION_MODEL model,
+                                EPDF_ACTION_NODE_ID node,
+                                void* buffer,
+                                unsigned long buflen);
+
+// Copy the /CharSet of a submit-form-type |node| (PDF 2.0) as UTF-8,
+// including the trailing NUL. Returns 0 when absent or for other node
+// types. |buffer| may be NULL to query the length.
+FPDF_EXPORT unsigned long FPDF_CALLCONV
+EPDFAction_GetNodeSubmitFormCharSet(EPDF_ACTION_MODEL model,
+                                    EPDF_ACTION_NODE_ID node,
+                                    void* buffer,
+                                    unsigned long buflen);
+
+// URI /IsMap for a uri-type |node| (default false). Returns false for other
+// node types; |is_map| is only written on success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDFAction_GetNodeURIIsMap(EPDF_ACTION_MODEL model,
+                           EPDF_ACTION_NODE_ID node,
+                           FPDF_BOOL* is_map);
+
 FPDF_EXPORT int FPDF_CALLCONV EPDFAction_GetNextCount(EPDF_ACTION_MODEL model,
                                                       EPDF_ACTION_NODE_ID node);
 
@@ -169,9 +259,19 @@ FPDF_EXPORT EPDF_ACTION_MODEL FPDF_CALLCONV
 EPDFDoc_GetNamedJavaScriptActionModel(FPDF_DOCUMENT document, int index);
 
 // Return the action form of catalog /OpenAction. Returns NULL when absent,
-// malformed, or when /OpenAction is a destination rather than an action.
+// malformed, or when /OpenAction is a destination rather than an action
+// (read the destination form with EPDFDoc_GetOpenActionDest()).
 FPDF_EXPORT EPDF_ACTION_MODEL FPDF_CALLCONV
 EPDFDoc_GetOpenActionModel(FPDF_DOCUMENT document);
+
+// Return the destination form of catalog /OpenAction as an explicit
+// FPDF_DEST — a named value resolves through the catalog, the same
+// normalization as FPDFLink_GetDest. Returns NULL when /OpenAction is
+// absent, malformed, or an action dictionary. The handle points into the
+// live document, like FPDFLink_GetDest, and is only valid while the
+// document stays open.
+FPDF_EXPORT FPDF_DEST FPDF_CALLCONV
+EPDFDoc_GetOpenActionDest(FPDF_DOCUMENT document);
 
 // Return one catalog /AA action selected by EPDF_DOCUMENT_ACTION_*.
 FPDF_EXPORT EPDF_ACTION_MODEL FPDF_CALLCONV


### PR DESCRIPTION
Enhance the detached action model: add per-model budgets (payload bytes, target entries, JS code units) and constants for max targets and destination elements. Introduce ActionTargetRecord and capture Hide/ResetForm target lists (withholding partial/unrepresentable lists). Track URI IsMap, ResetForm flags, and Hide /H. Limit destination snapshot length. Expose new APIs: GetNodeTargetCount/Name/ObjectNumber, GetNodeHideFlag, GetNodeResetForm, GetNodeURIIsMap, and EPDFDoc_GetOpenActionDest. Update embedder tests to cover these behaviors and budget overflow handling.